### PR TITLE
change assertions to use solAssert

### DIFF
--- a/libiele/IeleBlock.cpp
+++ b/libiele/IeleBlock.cpp
@@ -2,6 +2,8 @@
 
 #include "IeleFunction.h"
 
+#include <libsolidity/interface/Exceptions.h>
+
 using namespace dev;
 using namespace dev::iele;
 
@@ -11,15 +13,15 @@ IeleBlock::IeleBlock(IeleContext *Ctx, const llvm::Twine &Name,
   if (F)
     insertInto(F, InsertBefore);
   else
-    assert(!InsertBefore &&
+    solAssert(!InsertBefore,
            "Cannot insert block before another block with no function!");
 
   setName(Name);
 }
 
 void IeleBlock::insertInto(IeleFunction *NewParent, IeleBlock *InsertBefore) {
-  assert(NewParent && "Expected a parent");
-  assert(!Parent && "Already has a parent");
+  solAssert(NewParent, "Expected a parent");
+  solAssert(!Parent, "Already has a parent");
 
   if (InsertBefore)
     NewParent->getIeleBlockList().insert(
@@ -36,15 +38,15 @@ void IeleBlock::setParent(IeleFunction *parent) {
   for (const IeleInstruction &I : instructions()) {
     for (const IeleValue *V : I.operands()) {
       if (const IeleLocalVariable *LV = llvm::dyn_cast<IeleLocalVariable>(V))
-        assert(LV->getParent() == parent &&
+        solAssert(LV->getParent() == parent,
                "Instruction operand belongs to a different function!");
       else if (const IeleBlock *B = llvm::dyn_cast<IeleBlock>(V))
-        assert(B->getParent() == parent &&
+        solAssert(B->getParent() == parent,
                "Instruction operand belongs to a different function!");
     }
 
     for (const IeleLocalVariable *LV : I.lvalues()) {
-      assert(LV->getParent() == parent &&
+      solAssert(LV->getParent() == parent,
              "Instruction lvalue belongs to a different function!");
     }
   }

--- a/libiele/IeleContract.cpp
+++ b/libiele/IeleContract.cpp
@@ -4,6 +4,8 @@
 #include "IeleIntConstant.h"
 #include "IeleValueSymbolTable.h"
 
+#include <libsolidity/interface/Exceptions.h>
+
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Program.h"
 
@@ -78,7 +80,7 @@ bytes IeleContract::toBinary() const {
   const StringRef output = tempout_str;
   const StringRef *redirects[] = {&input, &output, nullptr};
   int exit = ExecuteAndWait(program, args, nullptr, redirects);
-  assert(exit == 0);
+  solAssert(exit == 0, "Iele assembler failed to execute on " + tempin_str);
 
   std::ifstream read(tempout_str);
   std::stringstream buffer;

--- a/libiele/IeleValue.cpp
+++ b/libiele/IeleValue.cpp
@@ -8,6 +8,8 @@
 #include "IeleLocalVariable.h"
 #include "IeleValueSymbolTable.h"
 
+#include <libsolidity/interface/Exceptions.h>
+
 #include "llvm/ADT/SmallString.h"
 
 using namespace dev;
@@ -28,7 +30,7 @@ static bool getSymTab(IeleValue *V, IeleValueSymbolTable *&ST) {
     if (IeleFunction *P = LV->getParent())
       ST = P->getIeleValueSymbolTable();
   } else {
-    assert(llvm::isa<IeleConstant>(V) && "Unknown value type!");
+    solAssert(llvm::isa<IeleConstant>(V), "Unknown value type!");
     return true;  // no name is setable for this.
   }
   return false;
@@ -40,14 +42,14 @@ IeleName *IeleValue::getIeleName() const {
   if (!HasName) return nullptr;
 
   auto I = Context->IeleNames.find(this);
-  assert(I != Context->IeleNames.end() &&
+  solAssert(I != Context->IeleNames.end(),
          "No name entry found!");
 
   return I->second;
 }
 
 void IeleValue::setIeleName(IeleName *IN) {
-  assert(HasName == Context->IeleNames.count(this) &&
+  solAssert(HasName == Context->IeleNames.count(this),
          "HasName bit out of sync!");
 
   if (!IN) {
@@ -75,7 +77,7 @@ void IeleValue::setName(const llvm::Twine &Name) {
 
   llvm::SmallString<256> NameData;
   llvm::StringRef NameRef = Name.toStringRef(NameData);
-  assert(NameRef.find_first_of(0) == llvm::StringRef::npos &&
+  solAssert(NameRef.find_first_of(0) == llvm::StringRef::npos,
          "Null bytes are not allowed in names");
 
   // Name isn't changing?

--- a/libiele/IeleValueSymbolTable.cpp
+++ b/libiele/IeleValueSymbolTable.cpp
@@ -1,5 +1,7 @@
 #include "IeleValueSymbolTable.h"
 
+#include <libsolidity/interface/Exceptions.h>
+
 #include "llvm/ADT/SmallString.h"
 
 using namespace dev;
@@ -25,7 +27,7 @@ IeleName *IeleValueSymbolTable::makeUniqueName(
 }
 
 void IeleValueSymbolTable::reinsertIeleValue(IeleValue* V) {
-  assert(V->hasName() && "Can't insert nameless Value into symbol table");
+  solAssert(V->hasName(), "Can't insert nameless Value into symbol table");
 
   // Try inserting the name, assuming it won't conflict.
   if (vmap.insert(V->getIeleName())) {

--- a/libiele/SymbolTableListTraits.h
+++ b/libiele/SymbolTableListTraits.h
@@ -2,6 +2,8 @@
 
 #include "IeleValueSymbolTable.h"
 
+#include <libsolidity/interface/Exceptions.h>
+
 #include "llvm/ADT/ilist.h"
 #include <cstddef>
 
@@ -86,7 +88,7 @@ public:
 template <typename ItemClass>
 void SymbolTableListTraits<ItemClass>::addNodeToList(
     ItemClass *V) {
-  assert(!V->getParent() && "Value already in a container!!");
+  solAssert(!V->getParent(), "Value already in a container!!");
   ItemParentClass *Owner = getListOwner();
   V->setParent(Owner);
   if (IeleValue *IV = llvm::dyn_cast<IeleValue>(V))
@@ -111,7 +113,7 @@ void SymbolTableListTraits<ItemClass>::transferNodesFromList(
   // We only have to do work here if transferring instructions between blocks
   // or local variables between instructions.
   ItemParentClass *NewIP = getListOwner(), *OldIP = L2.getListOwner();
-  assert(NewIP != OldIP && "Expected different list owners");
+  solAssert(NewIP != OldIP, "Expected different list owners");
 
   // We only have to update symbol table entries if we are transferring the
   // instructions or local variables to a different symtab object...


### PR DESCRIPTION
This is needed so the Boost test harness doesn't stop at the first failing assertion. @theo25 @dfilaretti please use solAssert instead of assert in the future.