### PR TITLE
fix byte encoding of integers

### DIFF
--- a/ciscript
+++ b/ciscript
@@ -29,6 +29,6 @@ sleep 3
 
 # run boost tests
 ./build/test/soltest -c no -e build/report.xml -r detailed -m xml -k build/log.xml -l all -f xml  -- --ipcpath build/ipcfile --testpath test
-xmllint --xpath "//TestCase[@assertions_failed!=@expected_failures]" build/report.xml && false
 iconv -f iso-8859-1 -t utf-8 build/log.xml -o build/log-utf8.xml && mv -f build/log-utf8.xml build/log.xml
+xmllint --xpath "//TestCase[@assertions_failed!=@expected_failures]" build/report.xml && false
 kill %1 %2

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -129,11 +129,21 @@ public:
 		{
 			std::vector<bytes> contractResult = callContractFunction(_sig, argument);
 			std::vector<bytes> cppResult = callCppAndEncodeResult(_cppFunction, argument);
+			std::string message = "\nExpected: [ ";
+
+			for (bytes const& val : cppResult) {
+				message += toHex(val) + " ";
+			}
+			message += "]\nActual: [ ";
+			for (bytes const& val : contractResult) {
+				message += toHex(val) + " ";
+			}
 			BOOST_CHECK_MESSAGE(
 				contractResult == cppResult,
 				"Computed values do not match.\nContract: " +
 					std::string("\nArgument: ") +
-					toHex(encode(argument))
+					toHex(encode(argument)) +
+					message + "]\n"
 			);
 		}
 	}

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -235,7 +235,7 @@ public:
 		} else if (_val == 0) {
 			return bytes(1, 0);
 		}
-		return toBigEndian(_val / 256, true) + bytes(1, _val % 256);
+		return toBigEndian(_val / 256, _val % 256 < 128) + bytes(1, _val % 256);
 	}
 
 	static bytes toBigEndian(u256 _val, bool _partial = false)
@@ -245,7 +245,7 @@ public:
 		} else if (_val == 0) {
 			return bytes(1, 0);
 		}
-		return toBigEndian(_val / 256, true) + bytes(1, (unsigned char)_val % 256);
+		return toBigEndian(_val / 256, _val % 256 < 128) + bytes(1, (unsigned char)_val % 256);
 	}
 
 private:


### PR DESCRIPTION
positive integers whose MSB is >= 128 need an extra zero byte at the beginning of their encoding. I'm not entirely sure why this was passing before, but it was definitely wrong. This should fix that.