### PR TITLE
accessor functions

### DIFF
--- a/iele-example-tests/auction/auction.iele.ref
+++ b/iele-example-tests/auction/auction.iele.ref
@@ -10,6 +10,30 @@ contract SimpleAuction {
 
 @ended = 5
 
+define public @"beneficiary()"() {
+entry:
+  %beneficiary.val = sload @beneficiary
+  ret %beneficiary.val
+}
+
+define public @"auctionEnd()"() {
+entry:
+  %auctionEnd.val = sload @auctionEnd
+  ret %auctionEnd.val
+}
+
+define public @"highestBidder()"() {
+entry:
+  %highestBidder.val = sload @highestBidder
+  ret %highestBidder.val
+}
+
+define public @"highestBid()"() {
+entry:
+  %highestBid.val = sload @highestBid
+  ret %highestBid.val
+}
+
 define @init(%_beneficiary_0, %_biddingTime_1) {
 entry:
   sstore %_beneficiary_0, @beneficiary

--- a/iele-example-tests/auction/create.iele.json
+++ b/iele-example-tests/auction/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0dcc73",
+                        "gas": "0x0d4713",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -146,6 +146,8 @@ private:
 
   void appendStateVariableInitialization(const ContractDefinition *contract);
 
+  void appendAccessorFunction(const VariableDeclaration *stateVariable);
+
   iele::IeleLocalVariable *appendIeleRuntimeAllocateMemory(
       iele::IeleValue *NumElems);
   iele::IeleLocalVariable *appendIeleRuntimeAllocateStorage(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1361,7 +1361,6 @@ BOOST_AUTO_TEST_CASE(constructor)
 	testContractAgainstCpp("get(uint256)", get, u256(7));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(simple_accessor, 1)
 BOOST_AUTO_TEST_CASE(simple_accessor)
 {
 	char const* sourceCode = R"(
@@ -2941,7 +2940,6 @@ BOOST_AUTO_TEST_CASE(function_modifier_for_constructor)
 	ABI_CHECK(callContractFunction("getData()"), encodeArgs(4 | 2));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(function_modifier_multiple_times, 1)
 BOOST_AUTO_TEST_CASE(function_modifier_multiple_times)
 {
 	char const* sourceCode = R"(
@@ -3067,7 +3065,6 @@ BOOST_AUTO_TEST_CASE(default_fallback_throws)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(0));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(short_data_calls_fallback, 2)
 BOOST_AUTO_TEST_CASE(short_data_calls_fallback)
 {
 	char const* sourceCode = R"(
@@ -3083,7 +3080,7 @@ BOOST_AUTO_TEST_CASE(short_data_calls_fallback)
 	sendMessage(vector<bytes>(), "deposit", bytes(), false, 0);
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(2));
 	// should call function
-	sendMessage(vector<bytes>(), "fow", bytes(), false, 0);
+	sendMessage(vector<bytes>(), "fow()", bytes(), false, 0);
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(3));
 }
 
@@ -5787,7 +5784,6 @@ BOOST_AUTO_TEST_CASE(invalid_enum_as_external_arg)
 }
 
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(proper_order_of_overwriting_of_attributes, 2)
 BOOST_AUTO_TEST_CASE(proper_order_of_overwriting_of_attributes)
 {
 	// bug #1798
@@ -5973,7 +5969,6 @@ BOOST_AUTO_TEST_CASE(evm_exceptions_in_constructor_out_of_baund)
 	BOOST_CHECK(compileAndRunWithoutCheck(sourceCode, 0, "A") == bytes());
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(positive_integers_to_signed, 3)
 BOOST_AUTO_TEST_CASE(positive_integers_to_signed)
 {
 	char const* sourceCode = R"(
@@ -6985,7 +6980,6 @@ BOOST_AUTO_TEST_CASE(string_as_mapping_key)
 		), encodeArgs(u256(7 + i)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(accessor_for_state_variable, 1)
 BOOST_AUTO_TEST_CASE(accessor_for_state_variable)
 {
 	char const* sourceCode = R"(
@@ -6998,7 +6992,6 @@ BOOST_AUTO_TEST_CASE(accessor_for_state_variable)
 	ABI_CHECK(callContractFunction("ticketPrice()"), encodeArgs(u256(500)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(accessor_for_const_state_variable, 1)
 BOOST_AUTO_TEST_CASE(accessor_for_const_state_variable)
 {
 	char const* sourceCode = R"(
@@ -8945,7 +8938,7 @@ BOOST_AUTO_TEST_CASE(create_dynamic_array_with_zero_length)
 	ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(7)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(return_does_not_skip_modifier, 2)
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(return_does_not_skip_modifier, 1)
 BOOST_AUTO_TEST_CASE(return_does_not_skip_modifier)
 {
 	char const* sourceCode = R"(
@@ -8966,7 +8959,6 @@ BOOST_AUTO_TEST_CASE(return_does_not_skip_modifier)
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(9)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(break_in_modifier, 2)
 BOOST_AUTO_TEST_CASE(break_in_modifier)
 {
 	char const* sourceCode = R"(
@@ -8989,7 +8981,6 @@ BOOST_AUTO_TEST_CASE(break_in_modifier)
 	ABI_CHECK(callContractFunction("x()"), encodeArgs(u256(1)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(stacked_return_with_modifiers, 2)
 BOOST_AUTO_TEST_CASE(stacked_return_with_modifiers)
 {
 	char const* sourceCode = R"(
@@ -9224,7 +9215,7 @@ BOOST_AUTO_TEST_CASE(payable_function_calls_library)
 	ABI_CHECK(callContractFunctionWithValue("f()", 27), encodeArgs(u256(7)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(non_payable_throw, 6)
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(non_payable_throw, 7)
 BOOST_AUTO_TEST_CASE(non_payable_throw)
 {
 	char const* sourceCode = R"(
@@ -9513,7 +9504,6 @@ BOOST_AUTO_TEST_CASE(store_internal_unused_library_function_in_constructor)
 	ABI_CHECK(callContractFunction("t()"), encodeArgs(u256(7)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(same_function_in_construction_and_runtime, 1)
 BOOST_AUTO_TEST_CASE(same_function_in_construction_and_runtime)
 {
 	char const* sourceCode = R"(
@@ -10687,7 +10677,6 @@ BOOST_AUTO_TEST_CASE(keccak256_assembly)
 	ABI_CHECK(callContractFunction("i()"), vector<bytes>(1, fromHex("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(multi_modifiers, 2)
 BOOST_AUTO_TEST_CASE(multi_modifiers)
 {
 	// This triggered a bug in some version because the variable in the modifier was not


### PR DESCRIPTION
Ready for review.

To do: make accessor functions have `view` mutability (ie generate code that rejects payment)