### PR TITLE
API for getting the bitwidth of types with fixed bitwidth representation

### DIFF
--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -184,6 +184,15 @@ inline unsigned bytesRequired(T _i)
 	for (; _i != 0; ++i, _i >>= 8) {}
 	return i;
 }
+/// Determine bits required to encode the given integer value. @returns 0 if @a _i is zero.
+template <class T>
+inline unsigned bitsRequired(T _i)
+{
+	static_assert(std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed, "only unsigned types or bigint supported"); //bigint does not carry sign bit on shift
+	unsigned i = 0;
+	for (; _i != 0; ++i, _i >>= 1) {}
+	return i;
+}
 /// Concatenate the contents of a container onto a vector
 template <class T, class U> std::vector<T>& operator+=(std::vector<T>& _a, U const& _b)
 {

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2452,7 +2452,7 @@ unsigned FunctionType::calldataEncodedSize(bool _padded) const
 bigint FunctionType::getFixedBitwidth() const
 {
 	if (m_kind == Kind::External || m_kind == Kind::Internal)
-		return bigint(80);
+		return bigint(160);
 	else
 		solAssert(false, "Bitwidth of non-storable function type requested.");
 }

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1420,6 +1420,15 @@ bool ArrayType::isDynamicallyEncoded() const
 	return isDynamicallySized() || baseType()->isDynamicallyEncoded();
 }
 
+bigint ArrayType::getFixedBitwidth() const {
+	if (isDynamicallySized())
+		return bigint(0);
+
+	if (length() > MAX_ARRAY_SIZE)
+		BOOST_THROW_EXCEPTION(Error(Error::Type::TypeError) << errinfo_comment("Array too large."));
+	return length() * baseType()->getFixedBitwidth();
+}
+
 bigint ArrayType::storageSize() const
 {
 	if (isDynamicallySized())
@@ -1762,6 +1771,17 @@ bool StructType::isDynamicallyEncoded() const
 	return false;
 }
 
+bigint StructType::getFixedBitwidth() const {
+	bigint bitwidth;
+	for (auto const& t: memoryMemberTypes()) {
+		if (bigint b = t->getFixedBitwidth())
+			bitwidth += b;
+		else
+			return bigint(0);
+	}
+	return bitwidth;
+}
+
 bigint StructType::memorySize() const
 {
 	bigint size;
@@ -1965,6 +1985,14 @@ bool EnumType::operator==(Type const& _other) const
 	return other.m_enum == m_enum;
 }
 
+bigint EnumType::getFixedBitwidth() const {
+	size_t elements = numberOfMembers();
+	if (elements <= 1)
+		return bigint(1);
+	else
+		return dev::bitsRequired(elements - 1);
+}
+
 unsigned EnumType::storageBytes() const
 {
 	size_t elements = numberOfMembers();
@@ -2060,6 +2088,11 @@ string TupleType::toString(bool _short) const
 		str += (t ? t->toString(_short) : "") + ",";
 	str.pop_back();
 	return str + ")";
+}
+
+bigint TupleType::getFixedBitwidth() const
+{
+	solAssert(false, "Bitwidth of non-storable tuple type requested.");
 }
 
 bigint TupleType::storageSize() const
@@ -2414,6 +2447,14 @@ unsigned FunctionType::calldataEncodedSize(bool _padded) const
 	if (_padded)
 		size = ((size + 31) / 32) * 32;
 	return size;
+}
+
+bigint FunctionType::getFixedBitwidth() const
+{
+	if (m_kind == Kind::External || m_kind == Kind::Internal)
+		return bigint(80);
+	else
+		solAssert(false, "Bitwidth of non-storable function type requested.");
 }
 
 bigint FunctionType::storageSize() const
@@ -2803,6 +2844,11 @@ bool TypeType::operator==(Type const& _other) const
 	return *actualType() == *other.actualType();
 }
 
+bigint TypeType::getFixedBitwidth() const
+{
+	solAssert(false, "Bitwidth of non-storable type type requested.");
+}
+
 bigint TypeType::storageSize() const
 {
 	solAssert(false, "Storage size of non-storable type type requested.");
@@ -2870,9 +2916,14 @@ ModifierType::ModifierType(const ModifierDefinition& _modifier)
 	swap(params, m_parameterTypes);
 }
 
+bigint ModifierType::getFixedBitwidth() const
+{
+	solAssert(false, "Bitwidth of non-storable modifier type requested.");
+}
+
 bigint ModifierType::storageSize() const
 {
-	solAssert(false, "Storage size of non-storable type type requested.");
+	solAssert(false, "Storage size of non-storable modifier type requested.");
 }
 
 string ModifierType::richIdentifier() const

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2452,7 +2452,7 @@ unsigned FunctionType::calldataEncodedSize(bool _padded) const
 bigint FunctionType::getFixedBitwidth() const
 {
 	if (m_kind == Kind::External || m_kind == Kind::Internal)
-		return bigint(160);
+		solAssert(false, "not implemented yet");
 	else
 		solAssert(false, "Bitwidth of non-storable function type requested.");
 }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -202,23 +202,29 @@ public:
 	/// in calldata.
 	/// @note: This should actually not be called on types, where isDynamicallyEncoded returns true.
 	/// If @a _padded then it is assumed that each element is padded to a multiple of 32 bytes.
+	/// DEPRECATED
 	virtual unsigned calldataEncodedSize(bool _padded) const { (void)_padded; return 0; }
-	/// @returns the size of this data type in bytes when stored in memory.
-	virtual bigint memorySize() const { return storageSize(); }
 	/// Convenience version of @see calldataEncodedSize(bool)
+	/// DEPRECATED
 	unsigned calldataEncodedSize() const { return calldataEncodedSize(true); }
 	/// @returns true if the type is a dynamic array
 	virtual bool isDynamicallySized() const { return false; }
-	/// @returns true if the type is dynamically encoded in the ABI
+	/// @returns true if the type doesn't fit in a fixed number of storage/memory locations.
 	virtual bool isDynamicallyEncoded() const { return false; }
+    /// If the values of the type can be represented as fixed-width integers, @returns
+    /// the bitwidth else returns zero.
+    virtual bigint getFixedBitwidth() const { return bigint(0); }
 	/// @returns the number of storage slots required to hold this value in storage.
 	/// For dynamically "allocated" types, it returns the size of the statically allocated head,
 	virtual bigint storageSize() const { return 1; }
+	/// @returns the size of this data type in bytes when stored in memory.
+	virtual bigint memorySize() const { return storageSize(); }
 	/// Multiple small types can be packed into a single storage slot. If such a packing is possible
 	/// this function @returns the size in bytes smaller than 32. Data is moved to the next slot if
 	/// it does not fit.
 	/// In order to avoid computation at runtime of whether such moving is necessary, structs and
 	/// array data (not each element) always start a new slot.
+	/// DEPRECATED
 	virtual unsigned storageBytes() const { return 32; }
 	/// Returns true if the type can be stored in storage.
 	virtual bool canBeStored() const { return true; }
@@ -324,6 +330,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_bits / 8; }
+	virtual bigint getFixedBitwidth() const override { return bigint(m_bits < 256 ? m_bits : 0); }
 	virtual unsigned storageBytes() const override { return m_bits / 8; }
 	virtual bool isValueType() const override { return true; }
 
@@ -371,6 +378,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded = true) const override { return _padded ? 32 : m_totalBits / 8; }
+	virtual bigint getFixedBitwidth() const override { return bigint(m_totalBits); }
 	virtual unsigned storageBytes() const override { return m_totalBits / 8; }
 	virtual bool isValueType() const override { return true; }
 
@@ -508,6 +516,7 @@ public:
 	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded) const override { return _padded && m_bytes > 0 ? 32 : m_bytes; }
+	virtual bigint getFixedBitwidth() const override { return bigint(m_bytes * 8); }
 	virtual unsigned storageBytes() const override { return m_bytes; }
 	virtual bool isValueType() const override { return true; }
 
@@ -535,6 +544,7 @@ public:
 	virtual TypePointer binaryOperatorResult(Token::Value _operator, TypePointer const& _other) const override;
 
 	virtual unsigned calldataEncodedSize(bool _padded) const override{ return _padded ? 32 : 1; }
+	virtual bigint getFixedBitwidth() const override { return bigint(1); }
 	virtual unsigned storageBytes() const override { return 1; }
 	virtual bool isValueType() const override { return true; }
 
@@ -634,6 +644,7 @@ public:
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool isDynamicallySized() const override { return m_hasDynamicLength; }
 	virtual bool isDynamicallyEncoded() const override;
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return m_baseType->canLiveOutsideStorage(); }
 	virtual unsigned sizeOnStack() const override;
@@ -691,6 +702,7 @@ public:
 	{
 		return encodingType()->calldataEncodedSize(_padded);
 	}
+	virtual bigint getFixedBitwidth() const override { return bigint(80); }
 	virtual unsigned storageBytes() const override { return 20; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual unsigned sizeOnStack() const override { return m_super ? 0 : 1; }
@@ -747,6 +759,7 @@ public:
 	virtual bool operator==(Type const& _other) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool isDynamicallyEncoded() const override;
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint memorySize() const override;
 	virtual bigint storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }
@@ -804,6 +817,7 @@ public:
 	{
 		return encodingType()->calldataEncodedSize(_padded);
 	}
+	virtual bigint getFixedBitwidth() const override;
 	virtual unsigned storageBytes() const override;
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual std::string toString(bool _short) const override;
@@ -844,6 +858,7 @@ public:
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
 	virtual std::string toString(bool) const override;
 	virtual bool canBeStored() const override { return false; }
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override;
@@ -983,6 +998,7 @@ public:
 	virtual std::string toString(bool _short) const override;
 	virtual unsigned calldataEncodedSize(bool _padded) const override;
 	virtual bool canBeStored() const override { return m_kind == Kind::Internal || m_kind == Kind::External; }
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint storageSize() const override;
 	virtual unsigned storageBytes() const override;
 	virtual bool isValueType() const override { return true; }
@@ -1093,6 +1109,9 @@ public:
 		return _inLibrary ? shared_from_this() : TypePointer();
 	}
 	virtual bool dataStoredIn(DataLocation _location) const override { return _location == DataLocation::Storage; }
+	//virtual bool isDynamicallyEncoded() const override;
+	//virtual bigint getFixedBitwidth() const override;
+	//virtual bigint storageSize() const override;
 
 	TypePointer const& keyType() const { return m_keyType; }
 	TypePointer const& valueType() const { return m_valueType; }
@@ -1118,6 +1137,7 @@ public:
 	virtual std::string richIdentifier() const override;
 	virtual bool operator==(Type const& _other) const override;
 	virtual bool canBeStored() const override { return false; }
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override;
@@ -1140,6 +1160,7 @@ public:
 
 	virtual TypePointer binaryOperatorResult(Token::Value, TypePointer const&) const override { return TypePointer(); }
 	virtual bool canBeStored() const override { return false; }
+	virtual bigint getFixedBitwidth() const override;
 	virtual bigint storageSize() const override;
 	virtual bool canLiveOutsideStorage() const override { return false; }
 	virtual unsigned sizeOnStack() const override { return 0; }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -215,9 +215,8 @@ public:
     /// the bitwidth else returns zero.
     virtual bigint getFixedBitwidth() const { return bigint(0); }
 	/// @returns the number of storage slots required to hold this value in storage.
-	/// For dynamically "allocated" types, it returns the size of the statically allocated head,
 	virtual bigint storageSize() const { return 1; }
-	/// @returns the size of this data type in bytes when stored in memory.
+	/// @returns the number of memory slots required to hold this value in memory.
 	virtual bigint memorySize() const { return storageSize(); }
 	/// Multiple small types can be packed into a single storage slot. If such a packing is possible
 	/// this function @returns the size in bytes smaller than 32. Data is moved to the next slot if
@@ -702,7 +701,7 @@ public:
 	{
 		return encodingType()->calldataEncodedSize(_padded);
 	}
-	virtual bigint getFixedBitwidth() const override { return bigint(80); }
+	virtual bigint getFixedBitwidth() const override { return bigint(160); }
 	virtual unsigned storageBytes() const override { return 20; }
 	virtual bool canLiveOutsideStorage() const override { return true; }
 	virtual unsigned sizeOnStack() const override { return m_super ? 0 : 1; }


### PR DESCRIPTION
This PR add a method in the `Type` class of the Solidity AST that returns the number of bits needed to represent values of the various types if they can be represented in a fixed number of bits through serialization. Else it returns 0.

The API hasn't been implemented for the `MappingType`, as it will be part of the next PR.

This is ready for review.