### PR TITLE
Return and modifiers

### DIFF
--- a/libsolidity/codegen/IeleCompiler.cpp
+++ b/libsolidity/codegen/IeleCompiler.cpp
@@ -345,6 +345,8 @@ bool IeleCompiler::visit(const FunctionDefinition &function) {
   // We store the formal argument names, which we'll use when generating in-range
   // checks in case of a public function.
   std::vector<iele::IeleArgument *> parameters;
+  returnParameters.clear(); // otherwise, stuff keep getting added, regardless
+                            // of which function we are in (i.e. it breaks)
 
   // Visit formal arguments.
   for (const ASTPointer<const VariableDeclaration> &arg : function.parameters()) {
@@ -364,7 +366,7 @@ bool IeleCompiler::visit(const FunctionDefinition &function) {
   for (const ASTPointer<const VariableDeclaration> &ret : function.returnParameters()) {
     std::string genName = ret->name() + getNextVarSuffix();
     ReturnParameterNames.push_back(genName);
-    iele::IeleLocalVariable::Create(&Context, genName, CompilingFunction);
+    returnParameters.push_back(iele::IeleLocalVariable::Create(&Context, genName, CompilingFunction));
     // No need to keep track of the mapping for omitted return params, since
     // they will never be referenced.
     if (!(ret->name() == ""))
@@ -432,36 +434,20 @@ bool IeleCompiler::visit(const FunctionDefinition &function) {
       llvm::cast<iele::IeleLocalVariable>(RetParam), &*ret);
   }
 
+  // Make return block 
+  iele::IeleBlock *retBlock = iele::IeleBlock::Create(
+    &Context, "return");
+  
+  // Add it to stack of return locations
+  ReturnBlocks[0] = retBlock; // this is done once per function hence level 0
+
   // Visit function body (inc modifiers). 
   CompilingFunctionASTNode = &function;
   ModifierDepth = -1;
   appendModifierOrFunctionCode();
 
-  // Add a ret if the last block doesn't end with a ret instruction.
-  if (!CompilingBlock->endsWithRet()) {
-    if (function.returnParameters().size() == 0) { // add a ret void
-      iele::IeleInstruction::CreateRetVoid(CompilingBlock);
-    } else { // return declared parameters
-        llvm::SmallVector<iele::IeleValue *, 4> Returns;
-
-        // Find Symbol Table for this function
-        iele::IeleValueSymbolTable *ST =
-          CompilingFunction->getIeleValueSymbolTable();
-        solAssert(ST,
-                  "IeleCompiler: failed to access compiling function's symbol "
-                  "table.");
-
-        // Prepare arguments for the `ret` instruction by fetching the param names
-        for (const std::string paramName : ReturnParameterNames) {
-          iele::IeleValue *param = ST->lookup(paramName);
-          solAssert(param, "IeleCompiler: couldn't find parameter name in symbol table.");
-          Returns.push_back(param);
-        }
-
-        // Create `ret` instruction
-        iele::IeleInstruction::CreateRet(Returns, CompilingBlock);
-    }
-  }
+  // Append return block
+  appendReturn(function, ReturnParameterNames);
 
   // Append the exception blocks if needed.
   appendRevertBlocks();
@@ -469,6 +455,41 @@ bool IeleCompiler::visit(const FunctionDefinition &function) {
   CompilingBlock = nullptr;
   CompilingFunction = nullptr;
   return false;
+}
+
+void IeleCompiler::appendReturn(const FunctionDefinition &function, 
+    llvm::SmallVector<std::string, 4> ReturnParameterNames) {
+
+  solAssert(ReturnBlocks[0], "IeleCompiler: appendReturn error");
+
+  auto retBlock = ReturnBlocks[0];
+
+  // Append block
+  retBlock -> insertInto(CompilingFunction);
+  
+  // Set it as currently compiling block
+  CompilingBlock = retBlock;
+
+  if (function.returnParameters().size() == 0) { // add a ret void
+    iele::IeleInstruction::CreateRetVoid(CompilingBlock);
+  } else { // return declared parameters
+      llvm::SmallVector<iele::IeleValue *, 4> Returns;
+
+      // Find Symbol Table for this function
+      iele::IeleValueSymbolTable *ST =
+        CompilingFunction->getIeleValueSymbolTable();
+      solAssert(ST,
+                "IeleCompiler: failed to access compiling function's symbol "
+                "table.");
+
+      // Prepare arguments for the `ret` instruction by fetching the param names
+      for (const std::string paramName : ReturnParameterNames) {
+        iele::IeleValue *param = ST->lookup(paramName);
+        solAssert(param, "IeleCompiler: couldn't find return parameter name in symbol table:");
+        Returns.push_back(param);
+      }
+      iele::IeleInstruction::CreateRet(Returns, CompilingBlock);
+  }
 }
 
 void IeleCompiler::appendRevertBlocks(void) {
@@ -546,9 +567,10 @@ bool IeleCompiler::visit(const IfStatement &ifStatement) {
 bool IeleCompiler::visit(const Return &returnStatement) {
   const Expression *returnExpr = returnStatement.expression();
 
+  solAssert(ReturnBlocks[ModifierDepth], "IeleCompiler: return jmp destination not set");
+  
   if (!returnExpr) {
-    // Create ret void.
-    iele::IeleInstruction::CreateRetVoid(CompilingBlock);
+    connectWithUnconditionalJump(CompilingBlock, ReturnBlocks[ModifierDepth]);    
     return false;
   }
 
@@ -557,9 +579,13 @@ bool IeleCompiler::visit(const Return &returnStatement) {
   compileTuple(*returnExpr, Values);
 
   llvm::SmallVector<iele::IeleValue *, 4> ReturnValues;
-  
   appendTypeConversions(ReturnValues, Values, returnExpr->annotation().type, FunctionType(*CompilingFunctionASTNode).returnParameterTypes());
-  iele::IeleInstruction::CreateRet(ReturnValues, CompilingBlock);
+  for (unsigned i = 0; i < ReturnValues.size(); ++i) {
+    iele::IeleInstruction::CreateAssign(
+      returnParameters[i], ReturnValues[i], CompilingBlock);        
+  }
+  
+  connectWithUnconditionalJump(CompilingBlock, ReturnBlocks[ModifierDepth]);    
 
   return false;
 }
@@ -652,7 +678,19 @@ void IeleCompiler::appendModifierOrFunctionCode() {
 
   // Visit whatever is next (modifier's body or function body)
   if (codeBlock) {
+    iele::IeleBlock *JumpTarget;
+    if (ModifierDepth != 0) {
+      JumpTarget = iele::IeleBlock::Create(
+        &Context, "ret_jmp_dest");
+      ReturnBlocks[ModifierDepth] = JumpTarget;
+    }
+    
     codeBlock->accept(*this);
+
+    if (ModifierDepth != 0) {
+      JumpTarget -> insertInto(CompilingFunction);
+      CompilingBlock = JumpTarget;
+    }
   }
 
   ModifierDepth--;

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -125,11 +125,18 @@ private:
   // Infrastructure for handling modifiers (borrowed from ContractCompiler.cpp)
   // Lookup function modifier by name
   const ModifierDefinition &functionModifier(const std::string &_name) const;
+  void appendReturn(const FunctionDefinition &function, 
+                    llvm::SmallVector<std::string, 4> ReturnParameterNames); 
   // Appends one layer of function modifier code of the current function, or the
   // function body itself if the last modifier was reached.
   void appendModifierOrFunctionCode();
   unsigned ModifierDepth;
-
+  // Maps each level of modifiers with a return target
+  std::map<unsigned, iele::IeleBlock *> ReturnBlocks;  
+  // Return parameters of the current function 
+  // TODO: do we really want to have this here?
+  std::vector<iele::IeleLocalVariable *> returnParameters;
+  
   template <class ArgClass, class ReturnClass, class ExpressionClass>
   void compileFunctionArguments(ArgClass *Arguments, ReturnClass *Returns, const::std::vector<ASTPointer<ExpressionClass>> &arguments, const FunctionType &function);
 

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -2776,7 +2776,6 @@ BOOST_AUTO_TEST_CASE(function_modifier)
 	ABI_CHECK(callContractFunctionWithValue("getOne()", 1), encodeArgs(1));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(function_modifier_local_variables, 1)
 BOOST_AUTO_TEST_CASE(function_modifier_local_variables)
 {
 	char const* sourceCode = R"(
@@ -2816,7 +2815,6 @@ BOOST_AUTO_TEST_CASE(function_modifier_multi_invocation)
 	ABI_CHECK(callContractFunction("f(bool)", true), encodeArgs(2));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(function_modifier_multi_with_return, 1)
 BOOST_AUTO_TEST_CASE(function_modifier_multi_with_return)
 {
 	// Note that return sets the return variable and jumps to the end of the current function or
@@ -2901,7 +2899,6 @@ BOOST_AUTO_TEST_CASE(function_modifier_multiple_times)
 	ABI_CHECK(callContractFunction("a()"), encodeArgs(2 + 5 + 3));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(function_modifier_multiple_times_local_vars, 1)
 BOOST_AUTO_TEST_CASE(function_modifier_multiple_times_local_vars)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
(Do not review yet) 

This gives a different implementation to `return` so that it behaves as expected, especially in interaction with function modifiers.

Previously, Solidity's `return` was simply compiled into IELE's `ret`. Now things are a bit different, since essentially we compile `return` into `jmp`s to blocks, and only at the end eventually reach a `ret` (of which there's only 1 per function). 

To keep track of the return value, we use the explicit or implicit return parameters. 

TODO: add example here
