### PR TITLE
Fixes to the compilation tests after (u)int - (u)int256 separation

### DIFF
--- a/test/compilationTests/MultiSigWallet/Factory.sol
+++ b/test/compilationTests/MultiSigWallet/Factory.sol
@@ -11,9 +11,9 @@ contract Factory {
     function getInstantiationCount(address creator)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
-        return instantiations[creator].length;
+        return uint256(instantiations[creator].length);
     }
 
     /// @dev Registers contract in factory registry.

--- a/test/compilationTests/MultiSigWallet/MultiSigWallet.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWallet.sol
@@ -5,28 +5,28 @@ pragma solidity ^0.4.4;
 /// @author Stefan George - <stefan.george@consensys.net>
 contract MultiSigWallet {
 
-    uint constant public MAX_OWNER_COUNT = 50;
+    uint256 constant public MAX_OWNER_COUNT = 50;
 
-    event Confirmation(address indexed sender, uint indexed transactionId);
-    event Revocation(address indexed sender, uint indexed transactionId);
-    event Submission(uint indexed transactionId);
-    event Execution(uint indexed transactionId);
-    event ExecutionFailure(uint indexed transactionId);
-    event Deposit(address indexed sender, uint value);
+    event Confirmation(address indexed sender, uint256 indexed transactionId);
+    event Revocation(address indexed sender, uint256 indexed transactionId);
+    event Submission(uint256 indexed transactionId);
+    event Execution(uint256 indexed transactionId);
+    event ExecutionFailure(uint256 indexed transactionId);
+    event Deposit(address indexed sender, uint256 value);
     event OwnerAddition(address indexed owner);
     event OwnerRemoval(address indexed owner);
-    event RequirementChange(uint required);
+    event RequirementChange(uint256 required);
 
-    mapping (uint => Transaction) public transactions;
-    mapping (uint => mapping (address => bool)) public confirmations;
+    mapping (uint256 => Transaction) public transactions;
+    mapping (uint256 => mapping (address => bool)) public confirmations;
     mapping (address => bool) public isOwner;
     address[] public owners;
-    uint public required;
-    uint public transactionCount;
+    uint256 public required;
+    uint256 public transactionCount;
 
     struct Transaction {
         address destination;
-        uint value;
+        uint256 value;
         bytes data;
         bool executed;
     }
@@ -49,25 +49,25 @@ contract MultiSigWallet {
         _;
     }
 
-    modifier transactionExists(uint transactionId) {
+    modifier transactionExists(uint256 transactionId) {
         if (transactions[transactionId].destination == 0)
             throw;
         _;
     }
 
-    modifier confirmed(uint transactionId, address owner) {
+    modifier confirmed(uint256 transactionId, address owner) {
         if (!confirmations[transactionId][owner])
             throw;
         _;
     }
 
-    modifier notConfirmed(uint transactionId, address owner) {
+    modifier notConfirmed(uint256 transactionId, address owner) {
         if (confirmations[transactionId][owner])
             throw;
         _;
     }
 
-    modifier notExecuted(uint transactionId) {
+    modifier notExecuted(uint256 transactionId) {
         if (transactions[transactionId].executed)
             throw;
         _;
@@ -79,7 +79,7 @@ contract MultiSigWallet {
         _;
     }
 
-    modifier validRequirement(uint ownerCount, uint _required) {
+    modifier validRequirement(uint256 ownerCount, uint256 _required) {
         if (   ownerCount > MAX_OWNER_COUNT
             || _required > ownerCount
             || _required == 0
@@ -102,11 +102,11 @@ contract MultiSigWallet {
     /// @dev Contract constructor sets initial owners and required number of confirmations.
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
-    function MultiSigWallet(address[] _owners, uint _required)
+    function MultiSigWallet(address[] _owners, uint256 _required)
         public
-        validRequirement(_owners.length, _required)
+        validRequirement(uint256(_owners.length), _required)
     {
-        for (uint i=0; i<_owners.length; i++) {
+        for (uint256 i=0; i<_owners.length; i++) {
             if (isOwner[_owners[i]] || _owners[i] == 0)
                 throw;
             isOwner[_owners[i]] = true;
@@ -122,7 +122,7 @@ contract MultiSigWallet {
         onlyWallet
         ownerDoesNotExist(owner)
         notNull(owner)
-        validRequirement(owners.length + 1, required)
+        validRequirement(uint256(owners.length) + 1, required)
     {
         isOwner[owner] = true;
         owners.push(owner);
@@ -137,14 +137,14 @@ contract MultiSigWallet {
         ownerExists(owner)
     {
         isOwner[owner] = false;
-        for (uint i=0; i<owners.length - 1; i++)
+        for (uint256 i=0; i<uint256(owners.length) - 1; i++)
             if (owners[i] == owner) {
-                owners[i] = owners[owners.length - 1];
+                owners[i] = owners[uint256(owners.length) - 1];
                 break;
             }
-        owners.length -= 1;
+        owners.length = uint256(owners.length) - 1;
         if (required > owners.length)
-            changeRequirement(owners.length);
+            changeRequirement(uint256(owners.length));
         OwnerRemoval(owner);
     }
 
@@ -157,7 +157,7 @@ contract MultiSigWallet {
         ownerExists(owner)
         ownerDoesNotExist(newOwner)
     {
-        for (uint i=0; i<owners.length; i++)
+        for (uint256 i=0; i<owners.length; i++)
             if (owners[i] == owner) {
                 owners[i] = newOwner;
                 break;
@@ -170,10 +170,10 @@ contract MultiSigWallet {
 
     /// @dev Allows to change the number of required confirmations. Transaction has to be sent by wallet.
     /// @param _required Number of required confirmations.
-    function changeRequirement(uint _required)
+    function changeRequirement(uint256 _required)
         public
         onlyWallet
-        validRequirement(owners.length, _required)
+        validRequirement(uint256(owners.length), _required)
     {
         required = _required;
         RequirementChange(_required);
@@ -184,9 +184,9 @@ contract MultiSigWallet {
     /// @param value Transaction ether value.
     /// @param data Transaction data payload.
     /// @return Returns transaction ID.
-    function submitTransaction(address destination, uint value, bytes data)
+    function submitTransaction(address destination, uint256 value, bytes data)
         public
-        returns (uint transactionId)
+        returns (uint256 transactionId)
     {
         transactionId = addTransaction(destination, value, data);
         confirmTransaction(transactionId);
@@ -194,7 +194,7 @@ contract MultiSigWallet {
 
     /// @dev Allows an owner to confirm a transaction.
     /// @param transactionId Transaction ID.
-    function confirmTransaction(uint transactionId)
+    function confirmTransaction(uint256 transactionId)
         public
         ownerExists(msg.sender)
         transactionExists(transactionId)
@@ -207,7 +207,7 @@ contract MultiSigWallet {
 
     /// @dev Allows an owner to revoke a confirmation for a transaction.
     /// @param transactionId Transaction ID.
-    function revokeConfirmation(uint transactionId)
+    function revokeConfirmation(uint256 transactionId)
         public
         ownerExists(msg.sender)
         confirmed(transactionId, msg.sender)
@@ -219,7 +219,7 @@ contract MultiSigWallet {
 
     /// @dev Allows anyone to execute a confirmed transaction.
     /// @param transactionId Transaction ID.
-    function executeTransaction(uint transactionId)
+    function executeTransaction(uint256 transactionId)
         public
         notExecuted(transactionId)
     {
@@ -238,13 +238,13 @@ contract MultiSigWallet {
     /// @dev Returns the confirmation status of a transaction.
     /// @param transactionId Transaction ID.
     /// @return Confirmation status.
-    function isConfirmed(uint transactionId)
+    function isConfirmed(uint256 transactionId)
         public
         constant
         returns (bool)
     {
-        uint count = 0;
-        for (uint i=0; i<owners.length; i++) {
+        uint256 count = 0;
+        for (uint256 i=0; i<owners.length; i++) {
             if (confirmations[transactionId][owners[i]])
                 count += 1;
             if (count == required)
@@ -260,10 +260,10 @@ contract MultiSigWallet {
     /// @param value Transaction ether value.
     /// @param data Transaction data payload.
     /// @return Returns transaction ID.
-    function addTransaction(address destination, uint value, bytes data)
+    function addTransaction(address destination, uint256 value, bytes data)
         internal
         notNull(destination)
-        returns (uint transactionId)
+        returns (uint256 transactionId)
     {
         transactionId = transactionCount;
         transactions[transactionId] = Transaction({
@@ -282,12 +282,12 @@ contract MultiSigWallet {
     /// @dev Returns number of confirmations of a transaction.
     /// @param transactionId Transaction ID.
     /// @return Number of confirmations.
-    function getConfirmationCount(uint transactionId)
+    function getConfirmationCount(uint256 transactionId)
         public
         constant
-        returns (uint count)
+        returns (uint256 count)
     {
-        for (uint i=0; i<owners.length; i++)
+        for (uint256 i=0; i<owners.length; i++)
             if (confirmations[transactionId][owners[i]])
                 count += 1;
     }
@@ -299,9 +299,9 @@ contract MultiSigWallet {
     function getTransactionCount(bool pending, bool executed)
         public
         constant
-        returns (uint count)
+        returns (uint256 count)
     {
-        for (uint i=0; i<transactionCount; i++)
+        for (uint256 i=0; i<transactionCount; i++)
             if (   pending && !transactions[i].executed
                 || executed && transactions[i].executed)
                 count += 1;
@@ -320,14 +320,14 @@ contract MultiSigWallet {
     /// @dev Returns array with owner addresses, which confirmed transaction.
     /// @param transactionId Transaction ID.
     /// @return Returns array of owner addresses.
-    function getConfirmations(uint transactionId)
+    function getConfirmations(uint256 transactionId)
         public
         constant
         returns (address[] _confirmations)
     {
         address[] memory confirmationsTemp = new address[](owners.length);
-        uint count = 0;
-        uint i;
+        uint256 count = 0;
+        uint256 i;
         for (i=0; i<owners.length; i++)
             if (confirmations[transactionId][owners[i]]) {
                 confirmationsTemp[count] = owners[i];
@@ -344,14 +344,14 @@ contract MultiSigWallet {
     /// @param pending Include pending transactions.
     /// @param executed Include executed transactions.
     /// @return Returns array of transaction IDs.
-    function getTransactionIds(uint from, uint to, bool pending, bool executed)
+    function getTransactionIds(uint256 from, uint256 to, bool pending, bool executed)
         public
         constant
         returns (uint[] _transactionIds)
     {
         uint[] memory transactionIdsTemp = new uint[](transactionCount);
-        uint count = 0;
-        uint i;
+        uint256 count = 0;
+        uint256 i;
         for (i=0; i<transactionCount; i++)
             if (   pending && !transactions[i].executed
                 || executed && transactions[i].executed)

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletFactory.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletFactory.sol
@@ -11,7 +11,7 @@ contract MultiSigWalletFactory is Factory {
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
     /// @return Returns wallet address.
-    function create(address[] _owners, uint _required)
+    function create(address[] _owners, uint256 _required)
         public
         returns (address wallet)
     {

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimit.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimit.sol
@@ -6,11 +6,11 @@ import "MultiSigWallet.sol";
 /// @author Stefan George - <stefan.george@consensys.net>
 contract MultiSigWalletWithDailyLimit is MultiSigWallet {
 
-    event DailyLimitChange(uint dailyLimit);
+    event DailyLimitChange(uint256 dailyLimit);
 
-    uint public dailyLimit;
-    uint public lastDay;
-    uint public spentToday;
+    uint256 public dailyLimit;
+    uint256 public lastDay;
+    uint256 public spentToday;
 
     /*
      * Public functions
@@ -19,7 +19,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
     /// @param _owners List of initial owners.
     /// @param _required Number of required confirmations.
     /// @param _dailyLimit Amount in wei, which can be withdrawn without confirmations on a daily basis.
-    function MultiSigWalletWithDailyLimit(address[] _owners, uint _required, uint _dailyLimit)
+    function MultiSigWalletWithDailyLimit(address[] _owners, uint256 _required, uint256 _dailyLimit)
         public
         MultiSigWallet(_owners, _required)
     {
@@ -28,7 +28,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
 
     /// @dev Allows to change the daily limit. Transaction has to be sent by wallet.
     /// @param _dailyLimit Amount in wei.
-    function changeDailyLimit(uint _dailyLimit)
+    function changeDailyLimit(uint256 _dailyLimit)
         public
         onlyWallet
     {
@@ -38,7 +38,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
 
     /// @dev Allows anyone to execute a confirmed transaction or ether withdraws until daily limit is reached.
     /// @param transactionId Transaction ID.
-    function executeTransaction(uint transactionId)
+    function executeTransaction(uint256 transactionId)
         public
         notExecuted(transactionId)
     {
@@ -65,7 +65,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
     /// @dev Returns if amount is within daily limit and resets spentToday after one day.
     /// @param amount Amount to withdraw.
     /// @return Returns if amount is under daily limit.
-    function isUnderLimit(uint amount)
+    function isUnderLimit(uint256 amount)
         internal
         returns (bool)
     {
@@ -86,7 +86,7 @@ contract MultiSigWalletWithDailyLimit is MultiSigWallet {
     function calcMaxWithdraw()
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         if (now > lastDay + 24 hours)
             return dailyLimit;

--- a/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimitFactory.sol
+++ b/test/compilationTests/MultiSigWallet/MultiSigWalletWithDailyLimitFactory.sol
@@ -12,7 +12,7 @@ contract MultiSigWalletWithDailyLimitFactory is Factory {
     /// @param _required Number of required confirmations.
     /// @param _dailyLimit Amount in wei, which can be withdrawn without confirmations on a daily basis.
     /// @return Returns wallet address.
-    function create(address[] _owners, uint _required, uint _dailyLimit)
+    function create(address[] _owners, uint256 _required, uint256 _dailyLimit)
         public
         returns (address wallet)
     {

--- a/test/compilationTests/corion/moduleHandler.sol
+++ b/test/compilationTests/corion/moduleHandler.sol
@@ -76,8 +76,8 @@ contract moduleHandler is multiOwner, announcementTypes {
         (success, found, id) = getModuleIDByAddress(0x00);
         require( success );
         if ( ! found ) {
-            id = modules.length;
-            modules.length++;
+            id = uint256(modules.length);
+            modules.length = uint256(modules.length) + 1;
         }
         modules[id] = input;
     }

--- a/test/compilationTests/corion/multiOwner.sol
+++ b/test/compilationTests/corion/multiOwner.sol
@@ -59,7 +59,7 @@ contract multiOwner is safeMath {
         for ( uint256 a=0 ; a<doDB[doHash].length ; a++ ) {
             require( doDB[doHash][a] != msg.sender );
         }
-        if ( doDB[doHash].length+1 >= ownersForChange() ) {
+        if ( uint256(doDB[doHash].length)+1 >= ownersForChange() ) {
             delete doDB[doHash];
             return true;
         } else {

--- a/test/compilationTests/corion/schelling.sol
+++ b/test/compilationTests/corion/schelling.sol
@@ -70,14 +70,14 @@ contract schellingDB is safeMath, schellingVars {
         else { return (true, rounds[_id].totalAboveWeight, rounds[_id].totalBelowWeight, rounds[_id].reward, rounds[_id].blockHeight, rounds[_id].voted); }
     }
     function pushRound(uint256 _totalAboveWeight, uint256 _totalBelowWeight, uint256 _reward, uint256 _blockHeight, bool _voted) isOwner external returns(bool, uint256) {
-        return (true, rounds.push(_rounds(_totalAboveWeight, _totalBelowWeight, _reward, _blockHeight, _voted)));
+        return (true, uint256(rounds.push(_rounds(_totalAboveWeight, _totalBelowWeight, _reward, _blockHeight, _voted))));
     }
     function setRound(uint256 _id, uint256 _totalAboveWeight, uint256 _totalBelowWeight, uint256 _reward, uint256 _blockHeight, bool _voted) isOwner external returns(bool) {
         rounds[_id] = _rounds(_totalAboveWeight, _totalBelowWeight, _reward, _blockHeight, _voted);
         return true;
     }
     function getCurrentRound() constant returns(bool, uint256) {
-        return (true, rounds.length-1);
+        return (true, uint256(rounds.length)-1);
     }
     /*
         Voter

--- a/test/compilationTests/corion/token.sol
+++ b/test/compilationTests/corion/token.sol
@@ -73,7 +73,7 @@ contract token is safeMath, module, announcementTypes {
         if ( ! forReplace ) {
             require( db.replaceOwner(this) );
             assert( genesisAddr.length == genesisValue.length );
-            require( this.balance >= genesisAddr.length * 0.2 ether );
+            require( this.balance >= uint256(genesisAddr.length) * 0.2 ether );
             for ( uint256 a=0 ; a<genesisAddr.length ; a++ ) {
                 genesis[genesisAddr[a]] = true;
                 require( db.increase(genesisAddr[a], genesisValue[a]) );

--- a/test/compilationTests/gnosis/Events/CategoricalEvent.sol
+++ b/test/compilationTests/gnosis/Events/CategoricalEvent.sol
@@ -28,14 +28,14 @@ contract CategoricalEvent is Event {
     /// @return Sender's winnings
     function redeemWinnings()
         public
-        returns (uint winnings)
+        returns (uint256 winnings)
     {
         // Winning outcome has to be set
         require(isOutcomeSet);
         // Calculate winnings
-        winnings = outcomeTokens[uint(outcome)].balanceOf(msg.sender);
+        winnings = outcomeTokens[uint256(outcome)].balanceOf(msg.sender);
         // Revoke tokens from winning outcome
-        outcomeTokens[uint(outcome)].revoke(msg.sender, winnings);
+        outcomeTokens[uint256(outcome)].revoke(msg.sender, winnings);
         // Payout winnings
         require(collateralToken.transfer(msg.sender, winnings));
         WinningsRedemption(msg.sender, winnings);

--- a/test/compilationTests/gnosis/Events/Event.sol
+++ b/test/compilationTests/gnosis/Events/Event.sol
@@ -12,10 +12,10 @@ contract Event {
      *  Events
      */
     event OutcomeTokenCreation(OutcomeToken outcomeToken, uint8 index);
-    event OutcomeTokenSetIssuance(address indexed buyer, uint collateralTokenCount);
-    event OutcomeTokenSetRevocation(address indexed seller, uint outcomeTokenCount);
-    event OutcomeAssignment(int outcome);
-    event WinningsRedemption(address indexed receiver, uint winnings);
+    event OutcomeTokenSetIssuance(address indexed buyer, uint256 collateralTokenCount);
+    event OutcomeTokenSetRevocation(address indexed seller, uint256 outcomeTokenCount);
+    event OutcomeAssignment(int256 outcome);
+    event WinningsRedemption(address indexed receiver, uint256 winnings);
 
     /*
      *  Storage
@@ -23,7 +23,7 @@ contract Event {
     Token public collateralToken;
     Oracle public oracle;
     bool public isOutcomeSet;
-    int public outcome;
+    int256 public outcome;
     OutcomeToken[] public outcomeTokens;
 
     /*
@@ -50,7 +50,7 @@ contract Event {
 
     /// @dev Buys equal number of tokens of all outcomes, exchanging collateral tokens and sets of outcome tokens 1:1
     /// @param collateralTokenCount Number of collateral tokens
-    function buyAllOutcomes(uint collateralTokenCount)
+    function buyAllOutcomes(uint256 collateralTokenCount)
         public
     {
         // Transfer collateral tokens to events contract
@@ -63,7 +63,7 @@ contract Event {
 
     /// @dev Sells equal number of tokens of all outcomes, exchanging collateral tokens and sets of outcome tokens 1:1
     /// @param outcomeTokenCount Number of outcome tokens
-    function sellAllOutcomes(uint outcomeTokenCount)
+    function sellAllOutcomes(uint256 outcomeTokenCount)
         public
     {
         // Revoke sender's outcome tokens of all outcomes
@@ -111,9 +111,9 @@ contract Event {
     function getOutcomeTokenDistribution(address owner)
         public
         constant
-        returns (uint[] outcomeTokenDistribution)
+        returns (uint256[] outcomeTokenDistribution)
     {
-        outcomeTokenDistribution = new uint[](outcomeTokens.length);
+        outcomeTokenDistribution = new uint256[](outcomeTokens.length);
         for (uint8 i = 0; i < outcomeTokenDistribution.length; i++)
             outcomeTokenDistribution[i] = outcomeTokens[i].balanceOf(owner);
     }
@@ -124,5 +124,5 @@ contract Event {
 
     /// @dev Exchanges sender's winning outcome tokens for collateral tokens
     /// @return Sender's winnings
-    function redeemWinnings() public returns (uint);
+    function redeemWinnings() public returns (uint256);
 }

--- a/test/compilationTests/gnosis/Events/EventFactory.sol
+++ b/test/compilationTests/gnosis/Events/EventFactory.sol
@@ -11,7 +11,7 @@ contract EventFactory {
      *  Events
      */
     event CategoricalEventCreation(address indexed creator, CategoricalEvent categoricalEvent, Token collateralToken, Oracle oracle, uint8 outcomeCount);
-    event ScalarEventCreation(address indexed creator, ScalarEvent scalarEvent, Token collateralToken, Oracle oracle, int lowerBound, int upperBound);
+    event ScalarEventCreation(address indexed creator, ScalarEvent scalarEvent, Token collateralToken, Oracle oracle, int256 lowerBound, int256 upperBound);
 
     /*
      *  Storage
@@ -57,8 +57,8 @@ contract EventFactory {
     function createScalarEvent(
         Token collateralToken,
         Oracle oracle,
-        int lowerBound,
-        int upperBound
+        int256 lowerBound,
+        int256 upperBound
     )
         public
         returns (ScalarEvent eventContract)

--- a/test/compilationTests/gnosis/Events/ScalarEvent.sol
+++ b/test/compilationTests/gnosis/Events/ScalarEvent.sol
@@ -17,8 +17,8 @@ contract ScalarEvent is Event {
     /*
      *  Storage
      */
-    int public lowerBound;
-    int public upperBound;
+    int256 public lowerBound;
+    int256 public upperBound;
 
     /*
      *  Public functions
@@ -31,8 +31,8 @@ contract ScalarEvent is Event {
     function ScalarEvent(
         Token _collateralToken,
         Oracle _oracle,
-        int _lowerBound,
-        int _upperBound
+        int256 _lowerBound,
+        int256 _upperBound
     )
         public
         Event(_collateralToken, _oracle, 2)
@@ -47,7 +47,7 @@ contract ScalarEvent is Event {
     /// @return Sender's winnings
     function redeemWinnings()
         public
-        returns (uint winnings)
+        returns (uint256 winnings)
     {
         // Winning outcome has to be set
         require(isOutcomeSet);
@@ -62,10 +62,10 @@ contract ScalarEvent is Event {
         // Map outcome to outcome range
         else
             convertedWinningOutcome = uint24(OUTCOME_RANGE * (outcome - lowerBound) / (upperBound - lowerBound));
-        uint factorShort = OUTCOME_RANGE - convertedWinningOutcome;
-        uint factorLong = OUTCOME_RANGE - factorShort;
-        uint shortOutcomeTokenCount = outcomeTokens[SHORT].balanceOf(msg.sender);
-        uint longOutcomeTokenCount = outcomeTokens[LONG].balanceOf(msg.sender);
+        uint256 factorShort = OUTCOME_RANGE - convertedWinningOutcome;
+        uint256 factorLong = OUTCOME_RANGE - factorShort;
+        uint256 shortOutcomeTokenCount = outcomeTokens[SHORT].balanceOf(msg.sender);
+        uint256 longOutcomeTokenCount = outcomeTokens[LONG].balanceOf(msg.sender);
         winnings = shortOutcomeTokenCount.mul(factorShort).add(longOutcomeTokenCount.mul(factorLong)) / OUTCOME_RANGE;
         // Revoke all outcome tokens
         outcomeTokens[SHORT].revoke(msg.sender, shortOutcomeTokenCount);

--- a/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
+++ b/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
@@ -11,8 +11,8 @@ contract LMSRMarketMaker is MarketMaker {
     /*
      *  Constants
      */
-    uint constant ONE = 0x10000000000000000;
-    int constant EXP_LIMIT = 2352680790717288641401;
+    uint256 constant ONE = 0x10000000000000000;
+    int256 constant EXP_LIMIT = 2352680790717288641401;
 
     /*
      *  Public functions
@@ -22,25 +22,25 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param outcomeTokenIndex Index of outcome to buy
     /// @param outcomeTokenCount Number of outcome tokens to buy
     /// @return Cost
-    function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount)
+    function calcCost(Market market, uint8 outcomeTokenIndex, uint256 outcomeTokenCount)
         public
         constant
-        returns (uint cost)
+        returns (uint256 cost)
     {
         require(market.eventContract().getOutcomeCount() > 1);
-        int[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
+        int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
         // Calculate cost level based on net outcome token balances
-        int logN = Math.ln(netOutcomeTokensSold.length * ONE);
-        uint funding = market.funding();
-        int costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
+        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        uint256 funding = market.funding();
+        int256 costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Add outcome token count to net outcome token balance
-        require(int(outcomeTokenCount) >= 0);
-        netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].add(int(outcomeTokenCount));
+        require(int256(outcomeTokenCount) >= 0);
+        netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].add(int256(outcomeTokenCount));
         // Calculate cost level after balance was updated
-        int costLevelAfter = calcCostLevel(logN, netOutcomeTokensSold, funding);
+        int256 costLevelAfter = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Calculate cost as cost level difference
         require(costLevelAfter >= costLevelBefore);
-        cost = uint(costLevelAfter - costLevelBefore);
+        cost = uint256(costLevelAfter - costLevelBefore);
         // Take the ceiling to account for rounding
         if (cost / ONE * ONE == cost)
             cost /= ONE;
@@ -57,26 +57,26 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param outcomeTokenIndex Index of outcome to sell
     /// @param outcomeTokenCount Number of outcome tokens to sell
     /// @return Profit
-    function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount)
+    function calcProfit(Market market, uint8 outcomeTokenIndex, uint256 outcomeTokenCount)
         public
         constant
-        returns (uint profit)
+        returns (uint256 profit)
     {
         require(market.eventContract().getOutcomeCount() > 1);
-        int[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
+        int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
         // Calculate cost level based on net outcome token balances
-        int logN = Math.ln(netOutcomeTokensSold.length * ONE);
-        uint funding = market.funding();
-        int costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
+        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        uint256 funding = market.funding();
+        int256 costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Subtract outcome token count from the net outcome token balance
-        require(int(outcomeTokenCount) >= 0);
-        netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].sub(int(outcomeTokenCount));
+        require(int256(outcomeTokenCount) >= 0);
+        netOutcomeTokensSold[outcomeTokenIndex] = netOutcomeTokensSold[outcomeTokenIndex].sub(int256(outcomeTokenCount));
         // Calculate cost level after balance was updated
-        int costLevelAfter = calcCostLevel(logN, netOutcomeTokensSold, funding);
+        int256 costLevelAfter = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Calculate profit as cost level difference
         require(costLevelBefore >= costLevelAfter);
         // Take the floor
-        profit = uint(costLevelBefore - costLevelAfter) / ONE;
+        profit = uint256(costLevelBefore - costLevelAfter) / ONE;
     }
 
     /// @dev Returns marginal price of an outcome
@@ -86,12 +86,12 @@ contract LMSRMarketMaker is MarketMaker {
     function calcMarginalPrice(Market market, uint8 outcomeTokenIndex)
         public
         constant
-        returns (uint price)
+        returns (uint256 price)
     {
         require(market.eventContract().getOutcomeCount() > 1);
-        int[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
-        int logN = Math.ln(netOutcomeTokensSold.length * ONE);
-        uint funding = market.funding();
+        int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
+        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        uint256 funding = market.funding();
         // The price function is exp(quantities[i]/b) / sum(exp(q/b) for q in quantities)
         // To avoid overflow, calculate with
         // exp(quantities[i]/b - offset) / sum(exp(q/b - offset) for q in quantities)
@@ -108,10 +108,10 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param netOutcomeTokensSold Net outcome tokens sold by market
     /// @param funding Initial funding for market
     /// @return Cost level
-    function calcCostLevel(int logN, int[] netOutcomeTokensSold, uint funding)
+    function calcCostLevel(int256 logN, int256[] netOutcomeTokensSold, uint256 funding)
         private
         constant
-        returns(int costLevel)
+        returns(int256 costLevel)
     {
         // The cost function is C = b * log(sum(exp(q/b) for q in quantities)).
         // To avoid overflow, we need to calc with an exponent offset:
@@ -119,7 +119,7 @@ contract LMSRMarketMaker is MarketMaker {
         var (sum, offset, ) = sumExpOffset(logN, netOutcomeTokensSold, funding, 0);
         costLevel = Math.ln(sum);
         costLevel = costLevel.add(offset);
-        costLevel = (costLevel.mul(int(ONE)) / logN).mul(int(funding));
+        costLevel = (costLevel.mul(int256(ONE)) / logN).mul(int256(funding));
     }
 
     /// @dev Calculates sum(exp(q/b - offset) for q in quantities), where offset is set
@@ -129,10 +129,10 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param funding Initial funding for market
     /// @param outcomeIndex Index of exponential term to extract (for use by marginal price function)
     /// @return A result structure composed of the sum, the offset used, and the summand associated with the supplied index
-    function sumExpOffset(int logN, int[] netOutcomeTokensSold, uint funding, uint8 outcomeIndex)
+    function sumExpOffset(int256 logN, int256[] netOutcomeTokensSold, uint256 funding, uint8 outcomeIndex)
         private
         constant
-        returns (uint sum, int offset, uint outcomeExpTerm)
+        returns (uint256 sum, int256 offset, uint256 outcomeExpTerm)
     {
         // Naive calculation of this causes an overflow
         // since anything above a bit over 133*ONE supplied to exp will explode
@@ -149,13 +149,13 @@ contract LMSRMarketMaker is MarketMaker {
         // BIG offset will cause the tiny quantities to go really negative
         // causing the associated exponentials to vanish.
 
-        int maxQuantity = Math.max(netOutcomeTokensSold);
-        require(logN >= 0 && int(funding) >= 0);
-        offset = maxQuantity.mul(logN) / int(funding);
+        int256 maxQuantity = Math.max(netOutcomeTokensSold);
+        require(logN >= 0 && int256(funding) >= 0);
+        offset = maxQuantity.mul(logN) / int256(funding);
         offset = offset.sub(EXP_LIMIT);
-        uint term;
+        uint256 term;
         for (uint8 i = 0; i < netOutcomeTokensSold.length; i++) {
-            term = Math.exp((netOutcomeTokensSold[i].mul(logN) / int(funding)).sub(offset));
+            term = Math.exp((netOutcomeTokensSold[i].mul(logN) / int256(funding)).sub(offset));
             if (i == outcomeIndex)
                 outcomeExpTerm = term;
             sum = sum.add(term);
@@ -171,9 +171,9 @@ contract LMSRMarketMaker is MarketMaker {
     function getNetOutcomeTokensSold(Market market)
         private
         constant
-        returns (int[] quantities)
+        returns (int256[] quantities)
     {
-        quantities = new int[](market.eventContract().getOutcomeCount());
+        quantities = new int256[](market.eventContract().getOutcomeCount());
         for (uint8 i = 0; i < quantities.length; i++)
             quantities[i] = market.netOutcomeTokensSold(i);
     }

--- a/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
+++ b/test/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
@@ -30,7 +30,7 @@ contract LMSRMarketMaker is MarketMaker {
         require(market.eventContract().getOutcomeCount() > 1);
         int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
         // Calculate cost level based on net outcome token balances
-        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        int256 logN = Math.ln(uint256(netOutcomeTokensSold.length) * ONE);
         uint256 funding = market.funding();
         int256 costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Add outcome token count to net outcome token balance
@@ -65,7 +65,7 @@ contract LMSRMarketMaker is MarketMaker {
         require(market.eventContract().getOutcomeCount() > 1);
         int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
         // Calculate cost level based on net outcome token balances
-        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        int256 logN = Math.ln(uint256(netOutcomeTokensSold.length) * ONE);
         uint256 funding = market.funding();
         int256 costLevelBefore = calcCostLevel(logN, netOutcomeTokensSold, funding);
         // Subtract outcome token count from the net outcome token balance
@@ -90,7 +90,7 @@ contract LMSRMarketMaker is MarketMaker {
     {
         require(market.eventContract().getOutcomeCount() > 1);
         int256[] memory netOutcomeTokensSold = getNetOutcomeTokensSold(market);
-        int256 logN = Math.ln(uint8(netOutcomeTokensSold.length) * ONE);
+        int256 logN = Math.ln(uint256(netOutcomeTokensSold.length) * ONE);
         uint256 funding = market.funding();
         // The price function is exp(quantities[i]/b) / sum(exp(q/b) for q in quantities)
         // To avoid overflow, calculate with

--- a/test/compilationTests/gnosis/MarketMakers/MarketMaker.sol
+++ b/test/compilationTests/gnosis/MarketMakers/MarketMaker.sol
@@ -8,7 +8,7 @@ contract MarketMaker {
     /*
      *  Public functions
      */
-    function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public constant returns (uint);
-    function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public constant returns (uint);
-    function calcMarginalPrice(Market market, uint8 outcomeTokenIndex) public constant returns (uint);
+    function calcCost(Market market, uint8 outcomeTokenIndex, uint256 outcomeTokenCount) public constant returns (uint256);
+    function calcProfit(Market market, uint8 outcomeTokenIndex, uint256 outcomeTokenCount) public constant returns (uint256);
+    function calcMarginalPrice(Market market, uint8 outcomeTokenIndex) public constant returns (uint256);
 }

--- a/test/compilationTests/gnosis/Markets/Campaign.sol
+++ b/test/compilationTests/gnosis/Markets/Campaign.sol
@@ -12,11 +12,11 @@ contract Campaign {
     /*
      *  Events
      */
-    event CampaignFunding(address indexed sender, uint funding);
-    event CampaignRefund(address indexed sender, uint refund);
+    event CampaignFunding(address indexed sender, uint256 funding);
+    event CampaignRefund(address indexed sender, uint256 refund);
     event MarketCreation(Market indexed market);
     event MarketClosing();
-    event FeeWithdrawal(address indexed receiver, uint fees);
+    event FeeWithdrawal(address indexed receiver, uint256 fees);
 
      /*
      *  Constants
@@ -31,10 +31,10 @@ contract Campaign {
     MarketMaker public marketMaker;
     Market public market;
     uint24 public fee;
-    uint public funding;
-    uint public deadline;
-    uint public finalBalance;
-    mapping (address => uint) public contributions;
+    uint256 public funding;
+    uint256 public deadline;
+    uint256 public finalBalance;
+    mapping (address => uint256) public contributions;
     Stages public stage;
 
     enum Stages {
@@ -75,8 +75,8 @@ contract Campaign {
         MarketFactory _marketFactory,
         MarketMaker _marketMaker,
         uint24 _fee,
-        uint _funding,
-        uint _deadline
+        uint256 _funding,
+        uint256 _deadline
     )
         public
     {
@@ -97,13 +97,13 @@ contract Campaign {
 
     /// @dev Allows to contribute to required market funding
     /// @param amount Amount of collateral tokens
-    function fund(uint amount)
+    function fund(uint256 amount)
         public
         timedTransitions
         atStage(Stages.AuctionStarted)
     {
-        uint raisedAmount = eventContract.collateralToken().balanceOf(this);
-        uint maxAmount = funding.sub(raisedAmount);
+        uint256 raisedAmount = eventContract.collateralToken().balanceOf(this);
+        uint256 maxAmount = funding.sub(raisedAmount);
         if (maxAmount < amount)
             amount = maxAmount;
         // Collect collateral tokens
@@ -120,7 +120,7 @@ contract Campaign {
         public
         timedTransitions
         atStage(Stages.AuctionFailed)
-        returns (uint refundAmount)
+        returns (uint256 refundAmount)
     {
         refundAmount = contributions[msg.sender];
         contributions[msg.sender] = 0;
@@ -166,7 +166,7 @@ contract Campaign {
     function withdrawFees()
         public
         atStage(Stages.MarketClosed)
-        returns (uint fees)
+        returns (uint256 fees)
     {
         fees = finalBalance.mul(contributions[msg.sender]) / funding;
         contributions[msg.sender] = 0;

--- a/test/compilationTests/gnosis/Markets/CampaignFactory.sol
+++ b/test/compilationTests/gnosis/Markets/CampaignFactory.sol
@@ -9,7 +9,7 @@ contract CampaignFactory {
     /*
      *  Events
      */
-    event CampaignCreation(address indexed creator, Campaign campaign, Event eventContract, MarketFactory marketFactory, MarketMaker marketMaker, uint24 fee, uint funding, uint deadline);
+    event CampaignCreation(address indexed creator, Campaign campaign, Event eventContract, MarketFactory marketFactory, MarketMaker marketMaker, uint24 fee, uint256 funding, uint256 deadline);
 
     /*
      *  Public functions
@@ -27,8 +27,8 @@ contract CampaignFactory {
         MarketFactory marketFactory,
         MarketMaker marketMaker,
         uint24 fee,
-        uint funding,
-        uint deadline
+        uint256 funding,
+        uint256 deadline
     )
         public
         returns (Campaign campaign)

--- a/test/compilationTests/gnosis/Markets/Market.sol
+++ b/test/compilationTests/gnosis/Markets/Market.sol
@@ -9,23 +9,23 @@ contract Market {
     /*
      *  Events
      */
-    event MarketFunding(uint funding);
+    event MarketFunding(uint256 funding);
     event MarketClosing();
-    event FeeWithdrawal(uint fees);
-    event OutcomeTokenPurchase(address indexed buyer, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint cost);
-    event OutcomeTokenSale(address indexed seller, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint profit);
-    event OutcomeTokenShortSale(address indexed buyer, uint8 outcomeTokenIndex, uint outcomeTokenCount, uint cost);
+    event FeeWithdrawal(uint256 fees);
+    event OutcomeTokenPurchase(address indexed buyer, uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 cost);
+    event OutcomeTokenSale(address indexed seller, uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 profit);
+    event OutcomeTokenShortSale(address indexed buyer, uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 cost);
 
     /*
      *  Storage
      */
     address public creator;
-    uint public createdAtBlock;
+    uint256 public createdAtBlock;
     Event public eventContract;
     MarketMaker public marketMaker;
     uint24 public fee;
-    uint public funding;
-    int[] public netOutcomeTokensSold;
+    uint256 public funding;
+    int256[] public netOutcomeTokensSold;
     Stages public stage;
 
     enum Stages {
@@ -37,11 +37,11 @@ contract Market {
     /*
      *  Public functions
      */
-    function fund(uint _funding) public;
+    function fund(uint256 _funding) public;
     function close() public;
-    function withdrawFees() public returns (uint);
-    function buy(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint maxCost) public returns (uint);
-    function sell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
-    function shortSell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
-    function calcMarketFee(uint outcomeTokenCost) public constant returns (uint);
+    function withdrawFees() public returns (uint256);
+    function buy(uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 maxCost) public returns (uint256);
+    function sell(uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 minProfit) public returns (uint256);
+    function shortSell(uint8 outcomeTokenIndex, uint256 outcomeTokenCount, uint256 minProfit) public returns (uint256);
+    function calcMarketFee(uint256 outcomeTokenCost) public constant returns (uint256);
 }

--- a/test/compilationTests/gnosis/Migrations.sol
+++ b/test/compilationTests/gnosis/Migrations.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.4;
 
 contract Migrations {
   address public owner;
-  uint public last_completed_migration;
+  uint256 public last_completed_migration;
 
   modifier restricted() {
     if (msg.sender == owner) _;
@@ -12,7 +12,7 @@ contract Migrations {
     owner = msg.sender;
   }
 
-  function setCompleted(uint completed) restricted {
+  function setCompleted(uint256 completed) restricted {
     last_completed_migration = completed;
   }
 

--- a/test/compilationTests/gnosis/Oracles/CentralizedOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/CentralizedOracle.sol
@@ -10,7 +10,7 @@ contract CentralizedOracle is Oracle {
      *  Events
      */
     event OwnerReplacement(address indexed newOwner);
-    event OutcomeAssignment(int outcome);
+    event OutcomeAssignment(int256 outcome);
 
     /*
      *  Storage
@@ -18,7 +18,7 @@ contract CentralizedOracle is Oracle {
     address public owner;
     bytes public ipfsHash;
     bool public isSet;
-    int public outcome;
+    int256 public outcome;
 
     /*
      *  Modifiers
@@ -57,7 +57,7 @@ contract CentralizedOracle is Oracle {
 
     /// @dev Sets event outcome
     /// @param _outcome Event outcome
-    function setOutcome(int _outcome)
+    function setOutcome(int256 _outcome)
         public
         isOwner
     {
@@ -83,7 +83,7 @@ contract CentralizedOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
         return outcome;
     }

--- a/test/compilationTests/gnosis/Oracles/DifficultyOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/DifficultyOracle.sol
@@ -9,20 +9,20 @@ contract DifficultyOracle is Oracle {
     /*
      *  Events
      */
-    event OutcomeAssignment(uint difficulty);
+    event OutcomeAssignment(uint256 difficulty);
 
     /*
      *  Storage
      */
-    uint public blockNumber;
-    uint public difficulty;
+    uint256 public blockNumber;
+    uint256 public difficulty;
 
     /*
      *  Public functions
      */
     /// @dev Contract constructor validates and sets target block number
     /// @param _blockNumber Target block number
-    function DifficultyOracle(uint _blockNumber)
+    function DifficultyOracle(uint256 _blockNumber)
         public
     {
         // Block has to be in the future
@@ -56,8 +56,8 @@ contract DifficultyOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
-        return int(difficulty);
+        return int256(difficulty);
     }
 }

--- a/test/compilationTests/gnosis/Oracles/DifficultyOracleFactory.sol
+++ b/test/compilationTests/gnosis/Oracles/DifficultyOracleFactory.sol
@@ -9,7 +9,7 @@ contract DifficultyOracleFactory {
     /*
      *  Events
      */
-    event DifficultyOracleCreation(address indexed creator, DifficultyOracle difficultyOracle, uint blockNumber);
+    event DifficultyOracleCreation(address indexed creator, DifficultyOracle difficultyOracle, uint256 blockNumber);
 
     /*
      *  Public functions
@@ -17,7 +17,7 @@ contract DifficultyOracleFactory {
     /// @dev Creates a new difficulty oracle contract
     /// @param blockNumber Target block number
     /// @return Oracle contract
-    function createDifficultyOracle(uint blockNumber)
+    function createDifficultyOracle(uint256 blockNumber)
         public
         returns (DifficultyOracle difficultyOracle)
     {

--- a/test/compilationTests/gnosis/Oracles/FutarchyOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/FutarchyOracle.sol
@@ -12,9 +12,9 @@ contract FutarchyOracle is Oracle {
     /*
      *  Events
      */
-    event FutarchyFunding(uint funding);
+    event FutarchyFunding(uint256 funding);
     event FutarchyClosing();
-    event OutcomeAssignment(uint winningMarketIndex);
+    event OutcomeAssignment(uint256 winningMarketIndex);
 
     /*
      *  Constants
@@ -27,8 +27,8 @@ contract FutarchyOracle is Oracle {
     address creator;
     Market[] public markets;
     CategoricalEvent public categoricalEvent;
-    uint public deadline;
-    uint public winningMarketIndex;
+    uint256 public deadline;
+    uint256 public winningMarketIndex;
     bool public isSet;
 
     /*
@@ -61,12 +61,12 @@ contract FutarchyOracle is Oracle {
         Token collateralToken,
         Oracle oracle,
         uint8 outcomeCount,
-        int lowerBound,
-        int upperBound,
+        int256 lowerBound,
+        int256 upperBound,
         MarketFactory marketFactory,
         MarketMaker marketMaker,
         uint24 fee,
-        uint _deadline
+        uint256 _deadline
     )
         public
     {
@@ -90,7 +90,7 @@ contract FutarchyOracle is Oracle {
 
     /// @dev Funds all markets with equal amount of funding
     /// @param funding Amount of funding
-    function fund(uint funding)
+    function fund(uint256 funding)
         public
         isCreator
     {
@@ -114,7 +114,7 @@ contract FutarchyOracle is Oracle {
         isCreator
     {
         // Winning outcome has to be set
-        Market market = markets[uint(getOutcome())];
+        Market market = markets[uint256(getOutcome())];
         require(categoricalEvent.isOutcomeSet() && market.eventContract().isOutcomeSet());
         // Close market and transfer all outcome tokens from winning outcome to this contract
         market.close();
@@ -133,10 +133,10 @@ contract FutarchyOracle is Oracle {
         // Outcome is not set yet and deadline has passed
         require(!isSet && deadline <= now);
         // Find market with highest marginal price for long outcome tokens
-        uint highestMarginalPrice = markets[0].marketMaker().calcMarginalPrice(markets[0], LONG);
-        uint highestIndex = 0;
+        uint256 highestMarginalPrice = markets[0].marketMaker().calcMarginalPrice(markets[0], LONG);
+        uint256 highestIndex = 0;
         for (uint8 i = 1; i < markets.length; i++) {
-            uint marginalPrice = markets[i].marketMaker().calcMarginalPrice(markets[i], LONG);
+            uint256 marginalPrice = markets[i].marketMaker().calcMarginalPrice(markets[i], LONG);
             if (marginalPrice > highestMarginalPrice) {
                 highestMarginalPrice = marginalPrice;
                 highestIndex = i;
@@ -162,8 +162,8 @@ contract FutarchyOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
-        return int(winningMarketIndex);
+        return int256(winningMarketIndex);
     }
 }

--- a/test/compilationTests/gnosis/Oracles/FutarchyOracleFactory.sol
+++ b/test/compilationTests/gnosis/Oracles/FutarchyOracleFactory.sol
@@ -15,12 +15,12 @@ contract FutarchyOracleFactory {
         Token collateralToken,
         Oracle oracle,
         uint8 outcomeCount,
-        int lowerBound,
-        int upperBound,
+        int256 lowerBound,
+        int256 upperBound,
         MarketFactory marketFactory,
         MarketMaker marketMaker,
         uint24 fee,
-        uint deadline
+        uint256 deadline
     );
 
     /*
@@ -55,12 +55,12 @@ contract FutarchyOracleFactory {
         Token collateralToken,
         Oracle oracle,
         uint8 outcomeCount,
-        int lowerBound,
-        int upperBound,
+        int256 lowerBound,
+        int256 upperBound,
         MarketFactory marketFactory,
         MarketMaker marketMaker,
         uint24 fee,
-        uint deadline
+        uint256 deadline
     )
         public
         returns (FutarchyOracle futarchyOracle)

--- a/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/MajorityOracle.sol
@@ -21,7 +21,7 @@ contract MajorityOracle is Oracle {
     {
         // At least 2 oracles should be defined
         require(_oracles.length > 2);
-        for (uint i = 0; i < _oracles.length; i++)
+        for (uint256 i = 0; i < _oracles.length; i++)
             // Oracle address cannot be null
             require(address(_oracles[i]) != 0);
         oracles = _oracles;
@@ -32,15 +32,15 @@ contract MajorityOracle is Oracle {
     /// @return Outcome
     function getStatusAndOutcome()
         public
-        returns (bool outcomeSet, int outcome)
+        returns (bool outcomeSet, int256 outcome)
     {
-        uint i;
-        int[] memory outcomes = new int[](oracles.length);
-        uint[] memory validations = new uint[](oracles.length);
+        uint256 i;
+        int256[] memory outcomes = new int256[](oracles.length);
+        uint256[] memory validations = new uint256[](oracles.length);
         for (i = 0; i < oracles.length; i++)
             if (oracles[i].isOutcomeSet()) {
-                int _outcome = oracles[i].getOutcome();
-                for (uint j = 0; j <= i; j++)
+                int256 _outcome = oracles[i].getOutcome();
+                for (uint256 j = 0; j <= i; j++)
                     if (_outcome == outcomes[j]) {
                         validations[j] += 1;
                         break;
@@ -51,8 +51,8 @@ contract MajorityOracle is Oracle {
                         break;
                     }
             }
-        uint outcomeValidations = 0;
-        uint outcomeIndex = 0;
+        uint256 outcomeValidations = 0;
+        uint256 outcomeIndex = 0;
         for (i = 0; i < oracles.length; i++)
             if (validations[i] > outcomeValidations) {
                 outcomeValidations = validations[i];
@@ -81,7 +81,7 @@ contract MajorityOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
         var (, winningOutcome) = getStatusAndOutcome();
         return winningOutcome;

--- a/test/compilationTests/gnosis/Oracles/Oracle.sol
+++ b/test/compilationTests/gnosis/Oracles/Oracle.sol
@@ -5,5 +5,5 @@ pragma solidity ^0.4.11;
 contract Oracle {
 
     function isOutcomeSet() public constant returns (bool);
-    function getOutcome() public constant returns (int);
+    function getOutcome() public constant returns (int256);
 }

--- a/test/compilationTests/gnosis/Oracles/SignedMessageOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/SignedMessageOracle.sol
@@ -10,16 +10,16 @@ contract SignedMessageOracle is Oracle {
      *  Events
      */
     event SignerReplacement(address indexed newSigner);
-    event OutcomeAssignment(int outcome);
+    event OutcomeAssignment(int256 outcome);
 
     /*
      *  Storage
      */
     address public signer;
     bytes32 public descriptionHash;
-    uint nonce;
+    uint256 nonce;
     bool public isSet;
-    int public outcome;
+    int256 public outcome;
 
     /*
      *  Modifiers
@@ -51,7 +51,7 @@ contract SignedMessageOracle is Oracle {
     /// @param v Signature parameter
     /// @param r Signature parameter
     /// @param s Signature parameter
-    function replaceSigner(address newSigner, uint _nonce, uint8 v, bytes32 r, bytes32 s)
+    function replaceSigner(address newSigner, uint256 _nonce, uint8 v, bytes32 r, bytes32 s)
         public
         isSigner
     {
@@ -69,7 +69,7 @@ contract SignedMessageOracle is Oracle {
     /// @param v Signature parameter
     /// @param r Signature parameter
     /// @param s Signature parameter
-    function setOutcome(int _outcome, uint8 v, bytes32 r, bytes32 s)
+    function setOutcome(int256 _outcome, uint8 v, bytes32 r, bytes32 s)
         public
     {
         // Result is not set yet and signer is valid
@@ -95,7 +95,7 @@ contract SignedMessageOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
         return outcome;
     }

--- a/test/compilationTests/gnosis/Oracles/UltimateOracle.sol
+++ b/test/compilationTests/gnosis/Oracles/UltimateOracle.sol
@@ -12,10 +12,10 @@ contract UltimateOracle is Oracle {
     /*
      *  Events
      */
-    event ForwardedOracleOutcomeAssignment(int outcome);
-    event OutcomeChallenge(address indexed sender, int outcome);
-    event OutcomeVote(address indexed sender, int outcome, uint amount);
-    event Withdrawal(address indexed sender, uint amount);
+    event ForwardedOracleOutcomeAssignment(int256 outcome);
+    event OutcomeChallenge(address indexed sender, int256 outcome);
+    event OutcomeVote(address indexed sender, int256 outcome, uint256 amount);
+    event Withdrawal(address indexed sender, uint256 amount);
 
     /*
      *  Storage
@@ -23,18 +23,18 @@ contract UltimateOracle is Oracle {
     Oracle public forwardedOracle;
     Token public collateralToken;
     uint8 public spreadMultiplier;
-    uint public challengePeriod;
-    uint public challengeAmount;
-    uint public frontRunnerPeriod;
+    uint256 public challengePeriod;
+    uint256 public challengeAmount;
+    uint256 public frontRunnerPeriod;
 
-    int public forwardedOutcome;
-    uint public forwardedOutcomeSetTimestamp;
-    int public frontRunner;
-    uint public frontRunnerSetTimestamp;
+    int256 public forwardedOutcome;
+    uint256 public forwardedOutcomeSetTimestamp;
+    int256 public frontRunner;
+    uint256 public frontRunnerSetTimestamp;
 
-    uint public totalAmount;
-    mapping (int => uint) public totalOutcomeAmounts;
-    mapping (address => mapping (int => uint)) public outcomeAmounts;
+    uint256 public totalAmount;
+    mapping (int256 => uint256) public totalOutcomeAmounts;
+    mapping (address => mapping (int256 => uint256)) public outcomeAmounts;
 
     /*
      *  Public functions
@@ -50,9 +50,9 @@ contract UltimateOracle is Oracle {
         Oracle _forwardedOracle,
         Token _collateralToken,
         uint8 _spreadMultiplier,
-        uint _challengePeriod,
-        uint _challengeAmount,
-        uint _frontRunnerPeriod
+        uint256 _challengePeriod,
+        uint256 _challengeAmount,
+        uint256 _frontRunnerPeriod
     )
         public
     {
@@ -86,7 +86,7 @@ contract UltimateOracle is Oracle {
 
     /// @dev Allows to challenge the oracle outcome
     /// @param _outcome Outcome to bid on
-    function challengeOutcome(int _outcome)
+    function challengeOutcome(int256 _outcome)
         public
     {
         // There was no challenge yet or the challenge period expired
@@ -104,10 +104,10 @@ contract UltimateOracle is Oracle {
     /// @dev Allows to challenge the oracle outcome
     /// @param _outcome Outcome to bid on
     /// @param amount Amount to bid
-    function voteForOutcome(int _outcome, uint amount)
+    function voteForOutcome(int256 _outcome, uint256 amount)
         public
     {
-        uint maxAmount = (totalAmount - totalOutcomeAmounts[_outcome]).mul(spreadMultiplier);
+        uint256 maxAmount = (totalAmount - totalOutcomeAmounts[_outcome]).mul(spreadMultiplier);
         if (amount > maxAmount)
             amount = maxAmount;
         // Outcome is challenged and front runner period is not over yet and tokens can be transferred
@@ -129,7 +129,7 @@ contract UltimateOracle is Oracle {
     /// @return Winnings
     function withdraw()
         public
-        returns (uint amount)
+        returns (uint256 amount)
     {
         // Outcome was challenged and ultimate outcome decided
         require(isFrontRunnerPeriodOver());
@@ -183,7 +183,7 @@ contract UltimateOracle is Oracle {
     function getOutcome()
         public
         constant
-        returns (int)
+        returns (int256)
     {
         if (isFrontRunnerPeriodOver())
             return frontRunner;

--- a/test/compilationTests/gnosis/Oracles/UltimateOracleFactory.sol
+++ b/test/compilationTests/gnosis/Oracles/UltimateOracleFactory.sol
@@ -15,9 +15,9 @@ contract UltimateOracleFactory {
         Oracle oracle,
         Token collateralToken,
         uint8 spreadMultiplier,
-        uint challengePeriod,
-        uint challengeAmount,
-        uint frontRunnerPeriod
+        uint256 challengePeriod,
+        uint256 challengeAmount,
+        uint256 frontRunnerPeriod
     );
 
     /*
@@ -35,9 +35,9 @@ contract UltimateOracleFactory {
         Oracle oracle,
         Token collateralToken,
         uint8 spreadMultiplier,
-        uint challengePeriod,
-        uint challengeAmount,
-        uint frontRunnerPeriod
+        uint256 challengePeriod,
+        uint256 challengeAmount,
+        uint256 frontRunnerPeriod
     )
         public
         returns (UltimateOracle ultimateOracle)

--- a/test/compilationTests/gnosis/Tokens/EtherToken.sol
+++ b/test/compilationTests/gnosis/Tokens/EtherToken.sol
@@ -10,8 +10,8 @@ contract EtherToken is StandardToken {
     /*
      *  Events
      */
-    event Deposit(address indexed sender, uint value);
-    event Withdrawal(address indexed receiver, uint value);
+    event Deposit(address indexed sender, uint256 value);
+    event Withdrawal(address indexed receiver, uint256 value);
 
     /*
      *  Constants
@@ -35,7 +35,7 @@ contract EtherToken is StandardToken {
 
     /// @dev Sells tokens in exchange for Ether, exchanging them 1:1
     /// @param value Number of tokens to sell
-    function withdraw(uint value)
+    function withdraw(uint256 value)
         public
     {
         // Balance covers value

--- a/test/compilationTests/gnosis/Tokens/OutcomeToken.sol
+++ b/test/compilationTests/gnosis/Tokens/OutcomeToken.sol
@@ -10,8 +10,8 @@ contract OutcomeToken is StandardToken {
     /*
      *  Events
      */
-    event Issuance(address indexed owner, uint amount);
-    event Revocation(address indexed owner, uint amount);
+    event Issuance(address indexed owner, uint256 amount);
+    event Revocation(address indexed owner, uint256 amount);
 
     /*
      *  Storage
@@ -40,7 +40,7 @@ contract OutcomeToken is StandardToken {
     /// @dev Events contract issues new tokens for address. Returns success
     /// @param _for Address of receiver
     /// @param outcomeTokenCount Number of tokens to issue
-    function issue(address _for, uint outcomeTokenCount)
+    function issue(address _for, uint256 outcomeTokenCount)
         public
         isEventContract
     {
@@ -52,7 +52,7 @@ contract OutcomeToken is StandardToken {
     /// @dev Events contract revokes tokens for address. Returns success
     /// @param _for Address of token holder
     /// @param outcomeTokenCount Number of tokens to revoke
-    function revoke(address _for, uint outcomeTokenCount)
+    function revoke(address _for, uint256 outcomeTokenCount)
         public
         isEventContract
     {

--- a/test/compilationTests/gnosis/Tokens/StandardToken.sol
+++ b/test/compilationTests/gnosis/Tokens/StandardToken.sol
@@ -10,9 +10,9 @@ contract StandardToken is Token {
     /*
      *  Storage
      */
-    mapping (address => uint) balances;
-    mapping (address => mapping (address => uint)) allowances;
-    uint totalTokens;
+    mapping (address => uint256) balances;
+    mapping (address => mapping (address => uint256)) allowances;
+    uint256 totalTokens;
 
     /*
      *  Public functions
@@ -21,7 +21,7 @@ contract StandardToken is Token {
     /// @param to Address of token receiver
     /// @param value Number of tokens to transfer
     /// @return Was transfer successful?
-    function transfer(address to, uint value)
+    function transfer(address to, uint256 value)
         public
         returns (bool)
     {
@@ -39,7 +39,7 @@ contract StandardToken is Token {
     /// @param to Address to where tokens are sent
     /// @param value Number of tokens to transfer
     /// @return Was transfer successful?
-    function transferFrom(address from, address to, uint value)
+    function transferFrom(address from, address to, uint256 value)
         public
         returns (bool)
     {
@@ -58,7 +58,7 @@ contract StandardToken is Token {
     /// @param spender Address of allowed account
     /// @param value Number of approved tokens
     /// @return Was approval successful?
-    function approve(address spender, uint value)
+    function approve(address spender, uint256 value)
         public
         returns (bool)
     {
@@ -74,7 +74,7 @@ contract StandardToken is Token {
     function allowance(address owner, address spender)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         return allowances[owner][spender];
     }
@@ -85,7 +85,7 @@ contract StandardToken is Token {
     function balanceOf(address owner)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         return balances[owner];
     }
@@ -95,7 +95,7 @@ contract StandardToken is Token {
     function totalSupply()
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         return totalTokens;
     }

--- a/test/compilationTests/gnosis/Tokens/Token.sol
+++ b/test/compilationTests/gnosis/Tokens/Token.sol
@@ -8,16 +8,16 @@ contract Token {
     /*
      *  Events
      */
-    event Transfer(address indexed from, address indexed to, uint value);
-    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 
     /*
      *  Public functions
      */
-    function transfer(address to, uint value) public returns (bool);
-    function transferFrom(address from, address to, uint value) public returns (bool);
-    function approve(address spender, uint value) public returns (bool);
-    function balanceOf(address owner) public constant returns (uint);
-    function allowance(address owner, address spender) public constant returns (uint);
-    function totalSupply() public constant returns (uint);
+    function transfer(address to, uint256 value) public returns (bool);
+    function transferFrom(address from, address to, uint256 value) public returns (bool);
+    function approve(address spender, uint256 value) public returns (bool);
+    function balanceOf(address owner) public constant returns (uint256);
+    function allowance(address owner, address spender) public constant returns (uint256);
+    function totalSupply() public constant returns (uint256);
 }

--- a/test/compilationTests/gnosis/Utils/Math.sol
+++ b/test/compilationTests/gnosis/Utils/Math.sol
@@ -10,9 +10,9 @@ library Math {
      *  Constants
      */
     // This is equal to 1 in our calculations
-    uint public constant ONE =  0x10000000000000000;
-    uint public constant LN2 = 0xb17217f7d1cf79ac;
-    uint public constant LOG2_E = 0x171547652b82fe177;
+    uint256 public constant ONE =  0x10000000000000000;
+    uint256 public constant LN2 = 0xb17217f7d1cf79ac;
+    uint256 public constant LOG2_E = 0x171547652b82fe177;
 
     /*
      *  Public functions
@@ -20,32 +20,32 @@ library Math {
     /// @dev Returns natural exponential function value of given x
     /// @param x x
     /// @return e**x
-    function exp(int x)
+    function exp(int256 x)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         // revert if x is > MAX_POWER, where
-        // MAX_POWER = int(mp.floor(mp.log(mpf(2**256 - 1) / ONE) * ONE))
+        // MAX_POWER = int256(mp.floor(mp.log(mpf(2**256 - 1) / ONE) * ONE))
         require(x <= 2454971259878909886679);
         // return 0 if exp(x) is tiny, using
-        // MIN_POWER = int(mp.floor(mp.log(mpf(1) / ONE) * ONE))
+        // MIN_POWER = int256(mp.floor(mp.log(mpf(1) / ONE) * ONE))
         if (x < -818323753292969962227)
             return 0;
         // Transform so that e^x -> 2^x
-        x = x * int(ONE) / int(LN2);
+        x = x * int256(ONE) / int256(LN2);
         // 2^x = 2^whole(x) * 2^frac(x)
         //       ^^^^^^^^^^ is a bit shift
         // so Taylor expand on z = frac(x)
-        int shift;
-        uint z;
+        int256 shift;
+        uint256 z;
         if (x >= 0) {
-            shift = x / int(ONE);
-            z = uint(x % int(ONE));
+            shift = x / int256(ONE);
+            z = uint256(x % int256(ONE));
         }
         else {
-            shift = x / int(ONE) - 1;
-            z = ONE - uint(-x % int(ONE));
+            shift = x / int256(ONE) - 1;
+            z = ONE - uint256(-x % int256(ONE));
         }
         // 2^x = 1 + (ln 2) x + (ln 2)^2/2! x^2 + ...
         //
@@ -53,15 +53,15 @@ library Math {
         // >>> from mpmath import mp
         // >>> mp.dps = 100
         // >>> ONE =  0x10000000000000000
-        // >>> print('\n'.join(hex(int(mp.log(2)**i / mp.factorial(i) * ONE)) for i in range(1, 7)))
+        // >>> print('\n'.join(hex(int256(mp.log(2)**i / mp.factorial(i) * ONE)) for i in range(1, 7)))
         // 0xb17217f7d1cf79ab
         // 0x3d7f7bff058b1d50
         // 0xe35846b82505fc5
         // 0x276556df749cee5
         // 0x5761ff9e299cc4
         // 0xa184897c363c3
-        uint zpow = z;
-        uint result = ONE;
+        uint256 zpow = z;
+        uint256 result = ONE;
         result += 0xb17217f7d1cf79ab * zpow / ONE;
         zpow = zpow * z / ONE;
         result += 0x3d7f7bff058b1d50 * zpow / ONE;
@@ -105,67 +105,67 @@ library Math {
     /// @dev Returns natural logarithm value of given x
     /// @param x x
     /// @return ln(x)
-    function ln(uint x)
+    function ln(uint256 x)
         public
         constant
-        returns (int)
+        returns (int256)
     {
         require(x > 0);
         // binary search for floor(log2(x))
-        int ilog2 = floorLog2(x);
-        int z;
+        int256 ilog2 = floorLog2(x);
+        int256 z;
         if (ilog2 < 0)
-            z = int(x << uint(-ilog2));
+            z = int256(x << uint256(-ilog2));
         else
-            z = int(x >> uint(ilog2));
+            z = int256(x >> uint256(ilog2));
         // z = x * 2^-⌊log₂x⌋
         // so 1 <= z < 2
         // and ln z = ln x - ⌊log₂x⌋/log₂e
         // so just compute ln z using artanh series
         // and calculate ln x from that
-        int term = (z - int(ONE)) * int(ONE) / (z + int(ONE));
-        int halflnz = term;
-        int termpow = term * term / int(ONE) * term / int(ONE);
+        int256 term = (z - int256(ONE)) * int256(ONE) / (z + int256(ONE));
+        int256 halflnz = term;
+        int256 termpow = term * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 3;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 5;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 7;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 9;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 11;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 13;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 15;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 17;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 19;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 21;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 23;
-        termpow = termpow * term / int(ONE) * term / int(ONE);
+        termpow = termpow * term / int256(ONE) * term / int256(ONE);
         halflnz += termpow / 25;
-        return (ilog2 * int(ONE)) * int(ONE) / int(LOG2_E) + 2 * halflnz;
+        return (ilog2 * int256(ONE)) * int256(ONE) / int256(LOG2_E) + 2 * halflnz;
     }
 
     /// @dev Returns base 2 logarithm value of given x
     /// @param x x
     /// @return logarithmic value
-    function floorLog2(uint x)
+    function floorLog2(uint256 x)
         public
         constant
-        returns (int lo)
+        returns (int256 lo)
     {
         lo = -64;
-        int hi = 193;
+        int256 hi = 193;
         // I use a shift here instead of / 2 because it floors instead of rounding towards 0
-        int mid = (hi + lo) >> 1;
+        int256 mid = (hi + lo) >> 1;
         while((lo + 1) < hi) {
-            if (mid < 0 && x << uint(-mid) < ONE || mid >= 0 && x >> uint(mid) < ONE)
+            if (mid < 0 && x << uint256(-mid) < ONE || mid >= 0 && x >> uint256(mid) < ONE)
                 hi = mid;
             else
                 lo = mid;
@@ -176,14 +176,14 @@ library Math {
     /// @dev Returns maximum of an array
     /// @param nums Numbers to look through
     /// @return Maximum number
-    function max(int[] nums)
+    function max(int256[] nums)
         public
         constant
-        returns (int max)
+        returns (int256 max)
     {
         require(nums.length > 0);
         max = -2**255;
-        for (uint i = 0; i < nums.length; i++)
+        for (uint256 i = 0; i < nums.length; i++)
             if (nums[i] > max)
                 max = nums[i];
     }
@@ -192,7 +192,7 @@ library Math {
     /// @param a First addend
     /// @param b Second addend
     /// @return Did no overflow occur?
-    function safeToAdd(uint a, uint b)
+    function safeToAdd(uint256 a, uint256 b)
         public
         constant
         returns (bool)
@@ -204,7 +204,7 @@ library Math {
     /// @param a Minuend
     /// @param b Subtrahend
     /// @return Did no underflow occur?
-    function safeToSub(uint a, uint b)
+    function safeToSub(uint256 a, uint256 b)
         public
         constant
         returns (bool)
@@ -216,7 +216,7 @@ library Math {
     /// @param a First factor
     /// @param b Second factor
     /// @return Did no overflow occur?
-    function safeToMul(uint a, uint b)
+    function safeToMul(uint256 a, uint256 b)
         public
         constant
         returns (bool)
@@ -228,10 +228,10 @@ library Math {
     /// @param a First addend
     /// @param b Second addend
     /// @return Sum
-    function add(uint a, uint b)
+    function add(uint256 a, uint256 b)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         require(safeToAdd(a, b));
         return a + b;
@@ -241,10 +241,10 @@ library Math {
     /// @param a Minuend
     /// @param b Subtrahend
     /// @return Difference
-    function sub(uint a, uint b)
+    function sub(uint256 a, uint256 b)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         require(safeToSub(a, b));
         return a - b;
@@ -254,10 +254,10 @@ library Math {
     /// @param a First factor
     /// @param b Second factor
     /// @return Product
-    function mul(uint a, uint b)
+    function mul(uint256 a, uint256 b)
         public
         constant
-        returns (uint)
+        returns (uint256)
     {
         require(safeToMul(a, b));
         return a * b;
@@ -267,7 +267,7 @@ library Math {
     /// @param a First addend
     /// @param b Second addend
     /// @return Did no overflow occur?
-    function safeToAdd(int a, int b)
+    function safeToAdd(int256 a, int256 b)
         public
         constant
         returns (bool)
@@ -279,7 +279,7 @@ library Math {
     /// @param a Minuend
     /// @param b Subtrahend
     /// @return Did no underflow occur?
-    function safeToSub(int a, int b)
+    function safeToSub(int256 a, int256 b)
         public
         constant
         returns (bool)
@@ -291,7 +291,7 @@ library Math {
     /// @param a First factor
     /// @param b Second factor
     /// @return Did no overflow occur?
-    function safeToMul(int a, int b)
+    function safeToMul(int256 a, int256 b)
         public
         constant
         returns (bool)
@@ -303,10 +303,10 @@ library Math {
     /// @param a First addend
     /// @param b Second addend
     /// @return Sum
-    function add(int a, int b)
+    function add(int256 a, int256 b)
         public
         constant
-        returns (int)
+        returns (int256)
     {
         require(safeToAdd(a, b));
         return a + b;
@@ -316,10 +316,10 @@ library Math {
     /// @param a Minuend
     /// @param b Subtrahend
     /// @return Difference
-    function sub(int a, int b)
+    function sub(int256 a, int256 b)
         public
         constant
-        returns (int)
+        returns (int256)
     {
         require(safeToSub(a, b));
         return a - b;
@@ -329,10 +329,10 @@ library Math {
     /// @param a First factor
     /// @param b Second factor
     /// @return Product
-    function mul(int a, int b)
+    function mul(int256 a, int256 b)
         public
         constant
-        returns (int)
+        returns (int256)
     {
         require(safeToMul(a, b));
         return a * b;

--- a/test/compilationTests/milestonetracker/MilestoneTracker.sol
+++ b/test/compilationTests/milestonetracker/MilestoneTracker.sol
@@ -43,18 +43,18 @@ contract MilestoneTracker {
     struct Milestone {
         string description;     // Description of this milestone
         string url;             // A link to more information (swarm gateway)
-        uint minCompletionDate; // Earliest UNIX time the milestone can be paid
-        uint maxCompletionDate; // Latest UNIX time the milestone can be paid
+        uint256 minCompletionDate; // Earliest UNIX time the milestone can be paid
+        uint256 maxCompletionDate; // Latest UNIX time the milestone can be paid
         address milestoneLeadLink;
                                 // Similar to `recipient`but for this milestone
         address reviewer;       // Can reject the completion of this milestone
-        uint reviewTime;        // How many seconds the reviewer has to review
+        uint256 reviewTime;        // How many seconds the reviewer has to review
         address paymentSource;  // Where the milestone payment is sent from
         bytes payData;          // Data defining how much ether is sent where
 
         MilestoneStatus status; // Current status of the milestone
                                 // (Completed, AuthorizedForPayment...)
-        uint doneTime;          // UNIX time when the milestone was marked DONE
+        uint256 doneTime;          // UNIX time when the milestone was marked DONE
     }
 
     // The list of all the milestones.
@@ -96,7 +96,7 @@ contract MilestoneTracker {
     event NewMilestoneListProposed();
     event NewMilestoneListUnproposed();
     event NewMilestoneListAccepted();
-    event ProposalStatusChanged(uint idProposal, MilestoneStatus newProposal);
+    event ProposalStatusChanged(uint256 idProposal, MilestoneStatus newProposal);
     event CampaignCanceled();
 
 
@@ -124,8 +124,8 @@ contract MilestoneTracker {
 /////////
 
     /// @return The number of milestones ever created even if they were canceled
-    function numberOfMilestones() constant returns (uint) {
-        return milestones.length;
+    function numberOfMilestones() constant returns (uint256) {
+        return uint256(milestones.length);
     }
 
 
@@ -168,11 +168,11 @@ contract MilestoneTracker {
     ///  has these fields:
     ///       string description,
     ///       string url,
-    ///       uint minCompletionDate,  // seconds since 1/1/1970 (UNIX time)
-    ///       uint maxCompletionDate,  // seconds since 1/1/1970 (UNIX time)
+    ///       uint256 minCompletionDate,  // seconds since 1/1/1970 (UNIX time)
+    ///       uint256 maxCompletionDate,  // seconds since 1/1/1970 (UNIX time)
     ///       address milestoneLeadLink,
     ///       address reviewer,
-    ///       uint reviewTime
+    ///       uint256 reviewTime
     ///       address paymentSource,
     ///       bytes payData,
     function proposeMilestones(bytes _newMilestones
@@ -202,7 +202,7 @@ contract MilestoneTracker {
     function acceptProposedMilestones(bytes32 _hashProposals
     ) onlyDonor campaignNotCanceled {
 
-        uint i;
+        uint256 i;
 
         if (!changingMilestones) throw;
         if (sha3(proposedMilestones) != _hashProposals) throw;
@@ -227,7 +227,8 @@ contract MilestoneTracker {
 
             var itmProposal = itrProposals.next();
 
-            Milestone milestone = milestones[milestones.length ++];
+            Milestone milestone = milestones[milestones.length];
+            milestones.length = uint256(milestones.length)+1;
 
             if (!itmProposal.isList()) throw;
 
@@ -235,11 +236,11 @@ contract MilestoneTracker {
 
             milestone.description = itrProposal.next().toAscii();
             milestone.url = itrProposal.next().toAscii();
-            milestone.minCompletionDate = itrProposal.next().toUint();
-            milestone.maxCompletionDate = itrProposal.next().toUint();
+            milestone.minCompletionDate = itrProposal.next().toUint256();
+            milestone.maxCompletionDate = itrProposal.next().toUint256();
             milestone.milestoneLeadLink = itrProposal.next().toAddress();
             milestone.reviewer = itrProposal.next().toAddress();
-            milestone.reviewTime = itrProposal.next().toUint();
+            milestone.reviewTime = itrProposal.next().toUint256();
             milestone.paymentSource = itrProposal.next().toAddress();
             milestone.payData = itrProposal.next().toData();
 
@@ -255,7 +256,7 @@ contract MilestoneTracker {
     /// @notice `onlyRecipientOrLeadLink`Marks a milestone as DONE and
     ///  ready for review
     /// @param _idMilestone ID of the milestone that has been completed
-    function markMilestoneComplete(uint _idMilestone)
+    function markMilestoneComplete(uint256 _idMilestone)
         campaignNotCanceled notChanging
     {
         if (_idMilestone >= milestones.length) throw;
@@ -273,7 +274,7 @@ contract MilestoneTracker {
 
     /// @notice `onlyReviewer` Approves a specific milestone
     /// @param _idMilestone ID of the milestone that is approved
-    function approveCompletedMilestone(uint _idMilestone)
+    function approveCompletedMilestone(uint256 _idMilestone)
         campaignNotCanceled notChanging
     {
         if (_idMilestone >= milestones.length) throw;
@@ -288,7 +289,7 @@ contract MilestoneTracker {
     ///  reverts the `milestone.status` back to the `AcceptedAndInProgress`
     ///  state
     /// @param _idMilestone ID of the milestone that is being rejected
-    function rejectMilestone(uint _idMilestone)
+    function rejectMilestone(uint256 _idMilestone)
         campaignNotCanceled notChanging
     {
         if (_idMilestone >= milestones.length) throw;
@@ -304,7 +305,7 @@ contract MilestoneTracker {
     ///  specified in `payData`; the recipient can only call this after the
     ///  `reviewTime` has elapsed
     /// @param _idMilestone ID of the milestone to be paid out
-    function requestMilestonePayment(uint _idMilestone
+    function requestMilestonePayment(uint256 _idMilestone
         ) campaignNotCanceled notChanging {
         if (_idMilestone >= milestones.length) throw;
         Milestone milestone = milestones[_idMilestone];
@@ -320,7 +321,7 @@ contract MilestoneTracker {
 
     /// @notice `onlyRecipient` Cancels a previously accepted milestone
     /// @param _idMilestone ID of the milestone to be canceled
-    function cancelMilestone(uint _idMilestone)
+    function cancelMilestone(uint256 _idMilestone)
         onlyRecipient campaignNotCanceled notChanging
     {
         if (_idMilestone >= milestones.length) throw;
@@ -336,7 +337,7 @@ contract MilestoneTracker {
     /// @notice `onlyArbitrator` Forces a milestone to be paid out as long as it
     /// has not been paid or canceled
     /// @param _idMilestone ID of the milestone to be paid out
-    function arbitrateApproveMilestone(uint _idMilestone
+    function arbitrateApproveMilestone(uint256 _idMilestone
     ) onlyArbitrator campaignNotCanceled notChanging {
         if (_idMilestone >= milestones.length) throw;
         Milestone milestone = milestones[_idMilestone];
@@ -354,7 +355,7 @@ contract MilestoneTracker {
     }
 
     // @dev This internal function is executed when the milestone is paid out
-    function authorizePayment(uint _idMilestone) internal {
+    function authorizePayment(uint256 _idMilestone) internal {
         if (_idMilestone >= milestones.length) throw;
         Milestone milestone = milestones[_idMilestone];
         // Recheck again to not pay twice

--- a/test/compilationTests/stringutils/strings.sol
+++ b/test/compilationTests/stringutils/strings.sol
@@ -35,11 +35,11 @@
  */
 library strings {
     struct slice {
-        uint _len;
-        uint _ptr;
+        uint256 _len;
+        uint256 _ptr;
     }
 
-    function memcpy(uint dest, uint src, uint len) private {
+    function memcpy(uint256 dest, uint256 src, uint256 len) private {
         // Copy word-length chunks while possible
         for(; len >= 32; len -= 32) {
             assembly {
@@ -50,7 +50,7 @@ library strings {
         }
 
         // Copy remaining bytes
-        uint mask = 256 ** (32 - len) - 1;
+        uint256 mask = 256 ** (32 - len) - 1;
         assembly {
             let srcpart := and(mload(src), not(mask))
             let destpart := and(mload(dest), mask)
@@ -64,11 +64,11 @@ library strings {
      * @return A newly allocated slice containing the entire string.
      */
     function toSlice(string self) internal returns (slice) {
-        uint ptr;
+        uint256 ptr;
         assembly {
             ptr := add(self, 0x20)
         }
-        return slice(bytes(self).length, ptr);
+        return slice(uint256(bytes(self).length), ptr);
     }
 
     /*
@@ -76,25 +76,25 @@ library strings {
      * @param self The value to find the length of.
      * @return The length of the string, from 0 to 32.
      */
-    function len(bytes32 self) internal returns (uint) {
-        uint ret;
+    function len(bytes32 self) internal returns (uint256) {
+        uint256 ret;
         if (self == 0)
             return 0;
         if (self & 0xffffffffffffffffffffffffffffffff == 0) {
             ret += 16;
-            self = bytes32(uint(self) / 0x100000000000000000000000000000000);
+            self = bytes32(uint256(self) / 0x100000000000000000000000000000000);
         }
         if (self & 0xffffffffffffffff == 0) {
             ret += 8;
-            self = bytes32(uint(self) / 0x10000000000000000);
+            self = bytes32(uint256(self) / 0x10000000000000000);
         }
         if (self & 0xffffffff == 0) {
             ret += 4;
-            self = bytes32(uint(self) / 0x100000000);
+            self = bytes32(uint256(self) / 0x100000000);
         }
         if (self & 0xffff == 0) {
             ret += 2;
-            self = bytes32(uint(self) / 0x10000);
+            self = bytes32(uint256(self) / 0x10000);
         }
         if (self & 0xff == 0) {
             ret += 1;
@@ -110,7 +110,7 @@ library strings {
      *         first null.
      */
     function toSliceB32(bytes32 self) internal returns (slice ret) {
-        // Allocate space for `self` in memory, copy it there, and point ret at it
+        // Allocate space for `self` in memory, copy it there, and point256 ret at it
         assembly {
             let ptr := mload(0x40)
             mstore(0x40, add(ptr, 0x20))
@@ -136,7 +136,7 @@ library strings {
      */
     function toString(slice self) internal returns (string) {
         var ret = new string(self._len);
-        uint retptr;
+        uint256 retptr;
         assembly { retptr := add(ret, 32) }
 
         memcpy(retptr, self._ptr, self._len);
@@ -151,11 +151,11 @@ library strings {
      * @param self The slice to operate on.
      * @return The length of the slice in runes.
      */
-    function len(slice self) internal returns (uint) {
+    function len(slice self) internal returns (uint256) {
         // Starting at ptr-31 means the LSB will be the byte we care about
         var ptr = self._ptr - 31;
         var end = ptr + self._len;
-        for (uint len = 0; ptr < end; len++) {
+        for (uint256 len = 0; ptr < end; len++) {
             uint8 b;
             assembly { b := and(mload(ptr), 0xFF) }
             if (b < 0x80) {
@@ -193,31 +193,31 @@ library strings {
      * @param other The second slice to compare.
      * @return The result of the comparison.
      */
-    function compare(slice self, slice other) internal returns (int) {
-        uint shortest = self._len;
+    function compare(slice self, slice other) internal returns (int256) {
+        uint256 shortest = self._len;
         if (other._len < self._len)
             shortest = other._len;
 
         var selfptr = self._ptr;
         var otherptr = other._ptr;
-        for (uint idx = 0; idx < shortest; idx += 32) {
-            uint a;
-            uint b;
+        for (uint256 idx = 0; idx < shortest; idx += 32) {
+            uint256 a;
+            uint256 b;
             assembly {
                 a := mload(selfptr)
                 b := mload(otherptr)
             }
             if (a != b) {
                 // Mask out irrelevant bytes and check again
-                uint mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
+                uint256 mask = ~(2 ** (8 * (32 - shortest + idx)) - 1);
                 var diff = (a & mask) - (b & mask);
                 if (diff != 0)
-                    return int(diff);
+                    return int256(diff);
             }
             selfptr += 32;
             otherptr += 32;
         }
-        return int(self._len) - int(other._len);
+        return int256(self._len) - int256(other._len);
     }
 
     /*
@@ -232,7 +232,7 @@ library strings {
 
     /*
      * @dev Extracts the first rune in the slice into `rune`, advancing the
-     *      slice to point to the next rune and returning `self`.
+     *      slice to point256 to the next rune and returning `self`.
      * @param self The slice to operate on.
      * @param rune The slice that will contain the first rune.
      * @return `rune`.
@@ -245,8 +245,8 @@ library strings {
             return rune;
         }
 
-        uint len;
-        uint b;
+        uint256 len;
+        uint256 b;
         // Load the first byte of the rune into the LSBs of b
         assembly { b := and(mload(sub(mload(add(self, 32)), 31)), 0xFF) }
         if (b < 0x80) {
@@ -284,18 +284,18 @@ library strings {
     }
 
     /*
-     * @dev Returns the number of the first codepoint in the slice.
+     * @dev Returns the number of the first codepoint256 in the slice.
      * @param self The slice to operate on.
-     * @return The number of the first codepoint in the slice.
+     * @return The number of the first codepoint256 in the slice.
      */
-    function ord(slice self) internal returns (uint ret) {
+    function ord(slice self) internal returns (uint256 ret) {
         if (self._len == 0) {
             return 0;
         }
 
-        uint word;
-        uint len;
-        uint div = 2 ** 248;
+        uint256 word;
+        uint256 len;
+        uint256 div = 2 ** 248;
 
         // Load the rune into the MSBs of b
         assembly { word:= mload(mload(add(self, 32))) }
@@ -319,7 +319,7 @@ library strings {
             return 0;
         }
 
-        for (uint i = 1; i < len; i++) {
+        for (uint256 i = 1; i < len; i++) {
             div = div / 256;
             b = (word / div) & 0xFF;
             if (b & 0xC0 != 0x80) {
@@ -456,9 +456,9 @@ library strings {
 
     // Returns the memory address of the first byte of the first occurrence of
     // `needle` in `self`, or the first byte after `self` if not found.
-    function findPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr) private returns (uint) {
-        uint ptr;
-        uint idx;
+    function findPtr(uint256 selflen, uint256 selfptr, uint256 needlelen, uint256 needleptr) private returns (uint256) {
+        uint256 ptr;
+        uint256 idx;
 
         if (needlelen <= selflen) {
             if (needlelen <= 32) {
@@ -495,8 +495,8 @@ library strings {
 
     // Returns the memory address of the first byte after the last occurrence of
     // `needle` in `self`, or the address of `self` if not found.
-    function rfindPtr(uint selflen, uint selfptr, uint needlelen, uint needleptr) private returns (uint) {
-        uint ptr;
+    function rfindPtr(uint256 selflen, uint256 selfptr, uint256 needlelen, uint256 needleptr) private returns (uint256) {
+        uint256 ptr;
 
         if (needlelen <= selflen) {
             if (needlelen <= 32) {
@@ -542,7 +542,7 @@ library strings {
      * @return `self`.
      */
     function find(slice self, slice needle) internal returns (slice) {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len -= ptr - self._ptr;
         self._ptr = ptr;
         return self;
@@ -557,7 +557,7 @@ library strings {
      * @return `self`.
      */
     function rfind(slice self, slice needle) internal returns (slice) {
-        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         self._len = ptr - self._ptr;
         return self;
     }
@@ -573,7 +573,7 @@ library strings {
      * @return `token`.
      */
     function split(slice self, slice needle, slice token) internal returns (slice) {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = self._ptr;
         token._len = ptr - self._ptr;
         if (ptr == self._ptr + self._len) {
@@ -610,7 +610,7 @@ library strings {
      * @return `token`.
      */
     function rsplit(slice self, slice needle, slice token) internal returns (slice) {
-        uint ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
+        uint256 ptr = rfindPtr(self._len, self._ptr, needle._len, needle._ptr);
         token._ptr = ptr;
         token._len = self._len - (ptr - self._ptr);
         if (ptr == self._ptr) {
@@ -641,8 +641,8 @@ library strings {
      * @param needle The text to search for in `self`.
      * @return The number of occurrences of `needle` found in `self`.
      */
-    function count(slice self, slice needle) internal returns (uint count) {
-        uint ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) + needle._len;
+    function count(slice self, slice needle) internal returns (uint256 count) {
+        uint256 ptr = findPtr(self._len, self._ptr, needle._len, needle._ptr) + needle._len;
         while (ptr <= self._ptr + self._len) {
             count++;
             ptr = findPtr(self._len - (ptr - self._ptr), ptr, needle._len, needle._ptr) + needle._len;
@@ -668,7 +668,7 @@ library strings {
      */
     function concat(slice self, slice other) internal returns (string) {
         var ret = new string(self._len + other._len);
-        uint retptr;
+        uint256 retptr;
         assembly { retptr := add(ret, 32) }
         memcpy(retptr, self._ptr, self._len);
         memcpy(retptr + self._len, other._ptr, other._len);
@@ -687,18 +687,18 @@ library strings {
         if (parts.length == 0)
             return "";
 
-        uint len = self._len * (parts.length - 1);
-        for(uint i = 0; i < parts.length; i++)
+        uint256 len = self._len * (uint256(parts.length) - 1);
+        for(uint256 i = 0; i < parts.length; i++)
             len += parts[i]._len;
 
         var ret = new string(len);
-        uint retptr;
+        uint256 retptr;
         assembly { retptr := add(ret, 32) }
 
         for(i = 0; i < parts.length; i++) {
             memcpy(retptr, parts[i]._ptr, parts[i]._len);
             retptr += parts[i]._len;
-            if (i < parts.length - 1) {
+            if (i < uint256(parts.length) - 1) {
                 memcpy(retptr, self._ptr, self._len);
                 retptr += self._len;
             }

--- a/test/compilationTests/zeppelin/MultisigWallet.sol
+++ b/test/compilationTests/zeppelin/MultisigWallet.sol
@@ -112,7 +112,7 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
    * @dev Clears the list of transactions pending approval.
    */
   function clearPending() internal {
-    uint256 length = pendingsIndex.length;
+    uint256 length = uint256(pendingsIndex.length);
     for (uint256 i = 0; i < length; ++i) {
       delete txs[pendingsIndex[i]];
     }

--- a/test/compilationTests/zeppelin/ownership/Shareable.sol
+++ b/test/compilationTests/zeppelin/ownership/Shareable.sol
@@ -149,7 +149,8 @@ contract Shareable {
       pending.yetNeeded = required;
       // reset which owners have confirmed (none) - set our bitmap to 0.
       pending.ownersDone = 0;
-      pending.index = pendingsIndex.length++;
+      pending.index = uint256(pendingsIndex.length);
+      pendingsIndex.length = uint256(pendingsIndex.length)+1;
       pendingsIndex[pending.index] = _operation;
     }
     // determine the bit to set for this owner.
@@ -177,7 +178,7 @@ contract Shareable {
    * @dev Clear the pending list.
    */
   function clearPending() internal {
-    uint256 length = pendingsIndex.length;
+    uint256 length = uint256(pendingsIndex.length);
     for (uint256 i = 0; i < length; ++i) {
       if (pendingsIndex[i] != 0) {
         delete pendings[pendingsIndex[i]];

--- a/test/compilationTests/zeppelin/token/PausableToken.sol
+++ b/test/compilationTests/zeppelin/token/PausableToken.sol
@@ -11,11 +11,11 @@ import '../lifecycle/Pausable.sol';
 
 contract PausableToken is StandardToken, Pausable {
 
-  function transfer(address _to, uint _value) whenNotPaused {
+  function transfer(address _to, uint256 _value) whenNotPaused {
     super.transfer(_to, _value);
   }
 
-  function transferFrom(address _from, address _to, uint _value) whenNotPaused {
+  function transferFrom(address _from, address _to, uint256 _value) whenNotPaused {
     super.transferFrom(_from, _to, _value);
   }
 }

--- a/test/compilationTests/zeppelin/token/TokenTimelock.sol
+++ b/test/compilationTests/zeppelin/token/TokenTimelock.sol
@@ -17,9 +17,9 @@ contract TokenTimelock {
   address beneficiary;
 
   // timestamp when token release is enabled
-  uint releaseTime;
+  uint256 releaseTime;
 
-  function TokenTimelock(ERC20Basic _token, address _beneficiary, uint _releaseTime) {
+  function TokenTimelock(ERC20Basic _token, address _beneficiary, uint256 _releaseTime) {
     require(_releaseTime > now);
     token = _token;
     beneficiary = _beneficiary;
@@ -33,7 +33,7 @@ contract TokenTimelock {
     require(msg.sender == beneficiary);
     require(now >= releaseTime);
 
-    uint amount = token.balanceOf(this);
+    uint256 amount = token.balanceOf(this);
     require(amount > 0);
 
     token.transfer(beneficiary, amount);

--- a/test/compilationTests/zeppelin/token/VestedToken.sol
+++ b/test/compilationTests/zeppelin/token/VestedToken.sol
@@ -51,7 +51,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
 
     if (tokenGrantsCount(_to) > MAX_GRANTS_PER_ADDRESS) throw;   // To prevent a user being spammed and have his balance locked (out of gas attack when calculating vesting).
 
-    uint256 count = grants[_to].push(
+    uint256 count = uint256(grants[_to].push(
                 TokenGrant(
                   _revokable ? msg.sender : 0, // avoid storing an extra 20 bytes when it is non-revokable
                   _value,
@@ -61,7 +61,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
                   _revokable,
                   _burnsOnRevoke
                 )
-              );
+              ));
 
     transfer(_to, _value);
 
@@ -90,8 +90,8 @@ contract VestedToken is StandardToken, LimitedTransferToken {
 
     // remove grant from array
     delete grants[_holder][_grantId];
-    grants[_holder][_grantId] = grants[_holder][grants[_holder].length.sub(1)];
-    grants[_holder].length -= 1;
+    grants[_holder][_grantId] = grants[_holder][uint256(grants[_holder].length).sub(1)];
+    grants[_holder].length = uint256(grants[_holder].length) - 1;
 
     balances[receiver] = balances[receiver].add(nonVested);
     balances[_holder] = balances[_holder].sub(nonVested);
@@ -131,7 +131,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    * @return A uint256 representing the total amount of grants.
    */
   function tokenGrantsCount(address _holder) constant returns (uint256 index) {
-    return grants[_holder].length;
+    return uint256(grants[_holder].length);
   }
 
   /**
@@ -240,7 +240,7 @@ contract VestedToken is StandardToken, LimitedTransferToken {
    */
   function lastTokenIsTransferableDate(address holder) constant public returns (uint64 date) {
     date = uint64(now);
-    uint256 grantIndex = grants[holder].length;
+    uint256 grantIndex = uint256(grants[holder].length);
     for (uint256 i = 0; i < grantIndex; i++) {
       date = Math.max64(grants[holder][i].vesting, date);
     }


### PR DESCRIPTION
This PR fixes the compilation tests that were failing to compile due to type error related with the separation of the `(u)int` and `(u)int256` types. Generally speaking the fix constitutes of replaces instances of `(u)int` that used to be syntactic sugar with `(u)int256`. Occasionally there was also a need to cast the result of evaluating the `length` member of arrays to `uint256`, since its type has changed to `uint`.

All compilation tests can now pass the front end and fail in the same way they did before the separation (commit 3499b3f).