### PR TITLE
Metadata bytes in IeleContract

### DIFF
--- a/iele-example-tests/auction/create.iele.json
+++ b/iele-example-tests/auction/create.iele.json
@@ -14,7 +14,7 @@
                     {
                         "out": ["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"],
                         "status": "",
-                        "gas": "0x0ca20f",
+                        "gas": "0x0c9e5f",
                         "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", 
                         "refund": ""
                     }

--- a/libiele/IeleContract.cpp
+++ b/libiele/IeleContract.cpp
@@ -164,6 +164,9 @@ bytes IeleContract::toBinary() const {
 
   std::remove(tempin_str.c_str());
   std::remove(tempout_str.c_str());
-  
-  return fromHex(hex, WhenError::Throw);
+
+  bytes Binary = fromHex(hex, WhenError::Throw);
+  Binary.push_back((byte)107);
+  Binary += AuxiliaryData;
+  return Binary;
 }

--- a/libiele/IeleContract.cpp
+++ b/libiele/IeleContract.cpp
@@ -165,8 +165,5 @@ bytes IeleContract::toBinary() const {
   std::remove(tempin_str.c_str());
   std::remove(tempout_str.c_str());
 
-  bytes Binary = fromHex(hex, WhenError::Throw);
-  Binary.push_back((byte)107);
-  Binary += AuxiliaryData;
-  return Binary;
+  return fromHex(hex, WhenError::Throw) + AuxiliaryData;
 }

--- a/libiele/IeleContract.h
+++ b/libiele/IeleContract.h
@@ -43,6 +43,7 @@ private:
   IeleFunctionListType IeleFunctionList;
   IeleGlobalVariableListType IeleGlobalVariableList;
   IeleContractListType IeleContractList;
+  bytes AuxiliaryData;
   std::unique_ptr<IeleValueSymbolTable> SymTab;
 
   friend class SymbolTableListTraits<IeleContract>;
@@ -83,6 +84,8 @@ public:
   void setStorageRuntimeNextFreePtrAddress(bigint nextFreePtrAddress) {
     NextFreePtrAddress = nextFreePtrAddress;
   }
+
+  void appendAuxiliaryDataToEnd(const bytes &data) { AuxiliaryData += data; }
 
   // Get the underlying elements of the IeleContract.
   //

--- a/libsolidity/codegen/IeleCompiler.cpp
+++ b/libsolidity/codegen/IeleCompiler.cpp
@@ -216,7 +216,8 @@ static bool checkForRecursiveStructs(const ContractDefinition &contract) {
 
 void IeleCompiler::compileContract(
     const ContractDefinition &contract,
-    const std::map<const ContractDefinition *, iele::IeleContract *> &contracts) {
+    const std::map<const ContractDefinition *, iele::IeleContract *> &contracts,
+    const bytes &metadata) {
 
 
   CompiledContracts = contracts;
@@ -462,6 +463,9 @@ void IeleCompiler::compileContract(
 
   // Store compilation result.
   CompiledContract = CompilingContract;
+
+  // Append the metadata to the compiled contract.
+  CompiledContract->appendAuxiliaryDataToEnd(metadata);
 }
 
 int IeleCompiler::getNextUniqueIntToken() {

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -45,7 +45,8 @@ public:
   // Compiles a contract.
   void compileContract(
       const ContractDefinition &contract,
-      const std::map<const ContractDefinition *, iele::IeleContract *> &contracts);
+      const std::map<const ContractDefinition *, iele::IeleContract *> &contracts,
+      const bytes &metadata);
 
   // Returns the compiled IeleContract.
   iele::IeleContract &assembly() const { return *CompiledContract; }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -726,7 +726,7 @@ void CompilerStack::compileContract(
 	solAssert(cborEncodedMetadata.size() <= 0xffff, "Metadata too large");
 	// 16-bit big endian length
 	cborEncodedMetadata += toCompactBigEndian(cborEncodedMetadata.size(), 2);
-	compiler->compileContract(_contract, _compiledContracts);
+	compiler->compileContract(_contract, _compiledContracts, cborEncodedMetadata);
 	compiledContract.compiler = compiler;
 
 	try

--- a/test/libsolidity/JSONCompiler.cpp
+++ b/test/libsolidity/JSONCompiler.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(basic_compilation)
 	BOOST_CHECK(contract["bytecode"].isString());
 	BOOST_CHECK_EQUAL(
 		dev::test::bytecodeSansMetadata(contract["bytecode"].asString()),
-		"63006700000000660000f60000"
+		"0000000d63006700000000660000f60000"
 	);
 	BOOST_CHECK(contract["functionHashes"].isObject());
 	BOOST_CHECK(contract["gasEstimates"].isObject());
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(single_compilation)
 	BOOST_CHECK(contract["bytecode"].isString());
 	BOOST_CHECK_EQUAL(
 		dev::test::bytecodeSansMetadata(contract["bytecode"].asString()),
-		"63006700000000660000f60000"
+		"0000000d63006700000000660000f60000"
 	);
 	BOOST_CHECK(contract["functionHashes"].isObject());
 	BOOST_CHECK(contract["gasEstimates"].isObject());

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -34,7 +34,6 @@ namespace test
 
 BOOST_AUTO_TEST_SUITE(Metadata)
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(metadata_stamp, 1)
 BOOST_AUTO_TEST_CASE(metadata_stamp)
 {
 	// Check that the metadata stamp is at the end of the runtime bytecode.
@@ -62,7 +61,6 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 	BOOST_CHECK(std::equal(expectation.begin(), expectation.end(), bytecode.end() - metadataCBORSize - 2));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(metadata_stamp_experimental, 1)
 BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 {
 	// Check that the metadata stamp is at the end of the runtime bytecode.

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -33,7 +33,7 @@ namespace test
 
 BOOST_FIXTURE_TEST_SUITE(Compiler, AnalysisFramework)
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(does_not_include_creation_time_only_internal_functions, 1)
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(does_not_include_creation_time_only_internal_functions, 2)
 BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -624,7 +624,7 @@ BOOST_AUTO_TEST_CASE(init_empty_dynamic_arrays)
 	BOOST_CHECK_LE(1600000, m_gasUsedNonOptimized);
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(optimise_multi_stores, 2)
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(optimise_multi_stores, 3)
 BOOST_AUTO_TEST_CASE(optimise_multi_stores)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(basic_compilation)
 	BOOST_CHECK(contract["evm"]["bytecode"]["object"].isString());
 	BOOST_CHECK_EQUAL(
 		dev::test::bytecodeSansMetadata(contract["evm"]["bytecode"]["object"].asString()),
-		"63006700000000660000f60000"
+		"0000000d63006700000000660000f60000"
 	);
 	BOOST_CHECK(contract["evm"]["assembly"].isString());
 	BOOST_CHECK(contract["evm"]["assembly"].asString().find(


### PR DESCRIPTION
The metadata bytes are generated by the compiler and then appended verbatim at the end of the iele binary for the contract.

Fixes #147 

This is redy for review.