### PR TITLE
C99 scoping

### DIFF
--- a/libsolidity/codegen/IeleCompiler.cpp
+++ b/libsolidity/codegen/IeleCompiler.cpp
@@ -46,7 +46,7 @@ std::string IeleCompiler::getIeleNameForFunction(
 std::string IeleCompiler::getIeleNameForLocalVariable(
     const VariableDeclaration *localVariable) {
   solAssert(localVariable->isLocalVariable() &&
-            !localVariable->isReturnParameter(),
+            !localVariable->isCallableParameter(),
             "IeleCompiler: requested unique local variable name for a "
             "non-local variable.");
   if (experimentalFeatureActive(ExperimentalFeature::V050))
@@ -729,7 +729,7 @@ bool IeleCompiler::visit(const FunctionDefinition &function) {
       param.push_back(iele::IeleLocalVariable::Create(&Context, genName, CompilingFunction));
     }
     IeleLValue *lvalue = RegisterLValue::Create(param);
-    VarNameMap[NumOfModifiers][localName] = lvalue; 
+    VarNameMap[NumOfModifiers][localName] = lvalue;
   }
 
   CompilingFunctionStatus =
@@ -1270,7 +1270,7 @@ bool IeleCompiler::visit(
         // Visit LHS. We lookup the LHS name in the compiling function's
         // variable name map, where we should find it.
         std::string varDeclName =
-          varDecl->isLocalVariable() && !varDecl->isReturnParameter() ?
+          varDecl->isLocalVariable() && !varDecl->isCallableParameter() ?
             getIeleNameForLocalVariable(varDecl) :
             varDecl->name();
         IeleLValue *LHSValue =
@@ -4926,7 +4926,7 @@ void IeleCompiler::endVisit(const Identifier &identifier) {
     }
   } else if (const VariableDeclaration *varDecl =
                dynamic_cast<const VariableDeclaration *>(declaration)) {
-    if (varDecl->isLocalVariable() && !varDecl->isReturnParameter())
+    if (varDecl->isLocalVariable() && !varDecl->isCallableParameter())
       name = getIeleNameForLocalVariable(varDecl);
   }
 

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -63,6 +63,16 @@ public:
     return {bytecode, std::map<size_t, std::string>()};
   }
 
+  // Update currently enabled set of experimental features.
+  void setExperimentalFeatures(const std::set<ExperimentalFeature> &features) {
+    ExperimentalFeatures = features;
+  }
+
+  // Returns true if the given feature is enabled.
+  bool experimentalFeatureActive(ExperimentalFeature feature) const {
+    return ExperimentalFeatures.count(feature);
+  }
+
   // Visitor interface.
   virtual bool visit(const FunctionDefinition &function) override;
   virtual bool visit(const IfStatement &ifStatement) override;
@@ -141,10 +151,12 @@ private:
   std::string getIeleNameForStateVariable(const VariableDeclaration *stateVariable);
   std::string getIeleNameForAccessor(const VariableDeclaration *stateVariable);
 
+  std::set<ExperimentalFeature> ExperimentalFeatures;
+
   // Fills in the ctorAuxParams data structure i.e. for each constructor in the 
   // class hierarchy, it computes the needed extra parameters and the additional
   // information needed to correctly handle them. 
-  void computeCtorsAuxParams ();
+  void computeCtorsAuxParams();
   
   // Data structure to hold auxiliary constructor params
   // Ctor -> Dest -> (paramName, Source)

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -150,6 +150,7 @@ private:
   std::string getIeleNameForFunction(const FunctionDefinition &function);
   std::string getIeleNameForStateVariable(const VariableDeclaration *stateVariable);
   std::string getIeleNameForAccessor(const VariableDeclaration *stateVariable);
+  std::string getIeleNameForLocalVariable(const VariableDeclaration *localVariable);
 
   std::set<ExperimentalFeature> ExperimentalFeatures;
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -705,6 +705,7 @@ void CompilerStack::compileContract(
 
 	shared_ptr<IeleCompiler> compiler = make_shared<IeleCompiler>();
 	Contract& compiledContract = m_contracts.at(_contract.fullyQualifiedName());
+	compiler->setExperimentalFeatures(_contract.sourceUnit().annotation().experimentalFeatures);
 	string metadata = createMetadata(compiledContract);
 	bytes cborEncodedHash =
 		// CBOR-encoding of the key "bzzr0"

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -363,6 +363,25 @@ BOOST_AUTO_TEST_CASE(C99_scoping_activation)
 	ABI_CHECK(callContractFunction("i()"), encodeArgs(3, 3));
 }
 
+BOOST_AUTO_TEST_CASE(C99_scoping_activation_loops)
+{
+  char const* sourceCode = R"(
+    pragma experimental "v0.5.0";
+    contract test {
+      function f(uint n) pure public returns (uint x1, uint x2) {
+        for (uint i = 1; i <= n; i++) {
+          uint y;
+          x1 = x1 + y + i;
+          y = i;
+          x2 = x2 + y + i;
+        }
+      }
+    }
+  )";
+  compileAndRun(sourceCode);
+  ABI_CHECK(callContractFunction("f(uint)", encodeArgs(3)), encodeArgs(6, 12));
+}
+
 BOOST_AUTO_TEST_CASE(recursive_calls)
 {
 	char const* sourceCode = R"(

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -315,7 +315,6 @@ BOOST_AUTO_TEST_CASE(conditional_expression_functions)
 	ABI_CHECK(callContractFunction("f(bool)", false), encodeArgs(u256(2)));
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(C99_scoping_activation, 4)
 BOOST_AUTO_TEST_CASE(C99_scoping_activation)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
This PR implements the c99 scoping rules that take effect when the version 0.5.0 pragma is present.

Fixes #61 

This is ready for review.