### PR TITLE
Enabled asm option for JSON output.

### DIFF
--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -58,8 +58,10 @@ public:
     return ret;
   }
 
-  std::string assemblyJSON(const StringMap &_sourceCodes = StringMap()) const {
-    return assemblyString(_sourceCodes);
+  Json::Value assemblyJSON(const StringMap &_sourceCodes = StringMap()) const {
+    Json::Value value;
+    value["code"] = assemblyString(_sourceCodes);
+    return value;
   }
 
   eth::LinkerObject assembledObject() const {

--- a/libsolidity/codegen/IeleCompiler.h
+++ b/libsolidity/codegen/IeleCompiler.h
@@ -58,6 +58,10 @@ public:
     return ret;
   }
 
+  std::string assemblyJSON(const StringMap &_sourceCodes = StringMap()) const {
+    return assemblyString(_sourceCodes);
+  }
+
   eth::LinkerObject assembledObject() const {
     bytes bytecode = CompiledContract->toBinary();
     return {bytecode, std::map<size_t, std::string>()};

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -402,7 +402,6 @@ string CompilerStack::assemblyString(string const& _contractName, StringMap _sou
 		return string();
 }
 
-/*
 /// FIXME: cache the JSON
 Json::Value CompilerStack::assemblyJSON(string const& _contractName, StringMap _sourceCodes) const
 {
@@ -412,7 +411,7 @@ Json::Value CompilerStack::assemblyJSON(string const& _contractName, StringMap _
 	else
 		return Json::Value();
 }
-*/
+
 vector<string> CompilerStack::sourceNames() const
 {
 	vector<string> names;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -218,12 +218,10 @@ public:
 	/// @arg _sourceCodes is the map of input files to source code strings
 	/// Prerequisite: Successful compilation.
 	std::string assemblyString(std::string const& _contractName, StringMap _sourceCodes = StringMap()) const;
-/*
 	/// @returns a JSON representation of the assembly.
 	/// @arg _sourceCodes is the map of input files to source code strings
 	/// Prerequisite: Successful compilation.
 	Json::Value assemblyJSON(std::string const& _contractName, StringMap _sourceCodes = StringMap()) const;
-*/
 	/// @returns a JSON representing the contract ABI.
 	/// Prerequisite: Successful call to parse or compile.
 	Json::Value const& contractABI(std::string const& _contractName) const;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -921,10 +921,8 @@ void CommandLineInterface::handleCombinedJSON()
 */
 		if (requests.count(g_strOpcodes))
 			contractData[g_strOpcodes] = solidity::disassemble(m_compiler->object(contractName).bytecode);
-/*
 		if (requests.count(g_strAsm))
 			contractData[g_strAsm] = m_compiler->assemblyJSON(contractName, m_sourceCodes);
-*/
 		if (requests.count(g_strSrcMap))
 		{
 			auto map = m_compiler->sourceMapping(contractName);
@@ -1219,11 +1217,9 @@ void CommandLineInterface::outputCompilationResults()
 		if (m_args.count(g_argAsm) || m_args.count(g_argAsmJson))
 		{
 			string ret;
-/*
 			if (m_args.count(g_argAsmJson))
 				ret = dev::jsonPrettyPrint(m_compiler->assemblyJSON(contract, m_sourceCodes));
 			else
-*/
 				ret = m_compiler->assemblyString(contract, m_sourceCodes);
 
 			if (m_args.count(g_argOutputDir))


### PR DESCRIPTION
Implemented to print the textual assembly string as the value of the "asm" field of the json representation.

Fixes #168 