### PR TITLE
Llvm dependency fix

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -63,7 +63,12 @@ foreach (BOOST_COMPONENT IN LISTS BOOST_COMPONENTS)
 endforeach()
 
 ## We use some of LLVM's libraries for the IELE backend
-## Ideally, we look for version 11. 
+## Ideally, we look for version 11 or newer.
+set(LLVM_MIN_VERSION "11.0.0")
 set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
-find_package(LLVM 11.0.0 QUIET CONFIG)
+SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+find_package(LLVM REQUIRED CONFIG)
+if (${LLVM_VERSION} STRLESS ${LLVM_MIN_VERSION})
+	message(FATAL_ERROR "Found LLVM version ${LLVM_VERSION}, which is older than the minimum supported version ${LLVM_MIN_VERSION}")
+endif()
 message(STATUS "Found LLVM version ${LLVM_VERSION}")

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -224,7 +224,7 @@ case $(uname -s) in
                     git \
                     libboost-all-dev \
                     unzip \
-                    llvm-5.0\
+                    llvm-11.0\
                     zlib1g-dev\
                     "$install_z3"
 
@@ -343,7 +343,7 @@ case $(uname -s) in
                     cmake \
                     git \
                     libboost-all-dev \
-                    llvm-5.0\
+                    llvm-11.0\
                     "$install_z3"
                 if [ "$CI" = true ]; then
                     # install Z3 from PPA if the distribution does not provide it


### PR DESCRIPTION
This PR updates the dependency installation script and the CMakeFiles to use and look for llvm 11 for Ubuntu and Debian.