### PR TITLE
Patch for type changes in m4 contracts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN    apt update        \
        cmake             \
        gcovr             \
        libboost-all-dev  \
+       libudev-dev       \
        libxml2-utils     \
        libz3-dev         \
        llvm-11           \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN    apt update        \
        gcovr             \
        libboost-all-dev  \
        libudev-dev       \
+       libusb-1.0-0      \
        libxml2-utils     \
        libz3-dev         \
        llvm-11           \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Regression Tests') {
       stages {
-        stage('Checkout code') { steps { dir('iog-pm') { git branch: 'separate-fetch', url: 'git@github.com:runtimeverification/iog-pm.git' } } }
+        stage('Checkout code') { steps { dir('iog-pm') { git branch: 'milestone4', url: 'git@github.com:runtimeverification/iog-pm.git' } } }
         stage('Milestone4 Tests') {
           environment {
             CONTRACTLIST = "${env.WORKSPACE}/test/milestone4-contracts.txt"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Regression Tests') {
       stages {
-        stage('Checkout code') { steps { dir('iog-pm') { git branch: 'milestone4', url: 'git@github.com:runtimeverification/iog-pm.git' } } }
+        stage('Checkout code') { steps { dir('iog-pm') { git branch: 'separate-fetch', url: 'git@github.com:runtimeverification/iog-pm.git' } } }
         stage('Milestone4 Tests') {
           environment {
             CONTRACTLIST = "${env.WORKSPACE}/test/milestone4-contracts.txt"
@@ -40,6 +40,7 @@ pipeline {
               sh '''
                 git submodule init
                 git submodule update --depth 1
+                ./fetch-all-modules.sh --verbose
                 patch -p1 < ${PATCH}
                 grep -v -x -F -f ${FAILING} ${CONTRACTLIST} > contracts.txt
                 export SOLC=${WORKSPACE}/build/solc/isolc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,12 +33,14 @@ pipeline {
           environment {
             CONTRACTLIST = "${env.WORKSPACE}/test/milestone4-contracts.txt"
             FAILING = "${env.WORKSPACE}/test/milestone4-contracts.failing"
+            PATCH = "${env.WORKSPACE}/test/milestone4-types.patch"
           }
           steps {
             dir('iog-pm') {
               sh '''
                 git submodule init
                 git submodule update --depth 1
+                patch -p1 < ${PATCH}
                 grep -v -x -F -f ${FAILING} ${CONTRACTLIST} > contracts.txt
                 export SOLC=${WORKSPACE}/build/solc/isolc
                 ./run-all-scripts.sh --filter contracts.txt --verbose --verbose

--- a/test/milestone4-contracts.failing
+++ b/test/milestone4-contracts.failing
@@ -1,4 +1,3 @@
-2key/contracts/2key/./libraries/PriceDiscovery.sol
 enzymefinance-protocol/contracts/./mocks/MockVaultLib.sol
 enzymefinance-protocol/contracts/./persistent/dispatcher/Dispatcher.sol
 enzymefinance-protocol/contracts/./persistent/vault/utils/ProxiableVaultLib.sol
@@ -7,12 +6,9 @@ enzymefinance-protocol/contracts/./persistent/vault/VaultLibBaseCore.sol
 enzymefinance-protocol/contracts/./persistent/vault/VaultProxy.sol
 enzymefinance-protocol/contracts/./release/core/fund/comptroller/ComptrollerProxy.sol
 enzymefinance-protocol/contracts/./release/core/fund-deployer/FundDeployer.sol
-enzymefinance-protocol/contracts/./release/extensions/policy-manager/policies/utils/AddressListPolicyMixin.sol
 enzymefinance-protocol/contracts/./release/infrastructure/price-feeds/derivatives/feeds/WdgldPriceFeed.sol
 enzymefinance-protocol/contracts/./release/peripheral/shares-requestors/AuthUserExecutedSharesRequestorProxy.sol
-enzymefinance-protocol/contracts/./release/utils/AddressArrayLib.sol
 enzymefinance-protocol/contracts/./release/utils/MakerDaoMath.sol
-enzymefinance-protocol/contracts/./release/utils/MathHelpers.sol
 enzymefinance-protocol/contracts/./release/utils/Proxy.sol
 evolutionland-furnace/src/./common/ECDSA.sol
 evolutionland-furnace/src/./DrillBaseProxy.sol
@@ -47,19 +43,16 @@ loopring-protocols/packages/loopring_v3/contracts/./aux/compression/ZeroDecompre
 loopring-protocols/packages/loopring_v3/contracts/./aux/fee-vault/ProtocolFeeVault.sol
 loopring-protocols/packages/loopring_v3/contracts/./aux/gas/ChiDiscount.sol
 loopring-protocols/packages/loopring_v3/contracts/./aux/migrate/MigrationToLoopringExchangeV2.sol
-loopring-protocols/packages/loopring_v3/contracts/./aux/token-sellers/UniswapTokenSeller.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/BlockVerifier.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/DefaultDepositContract.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/libexchange/ExchangeAdmins.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/libexchange/ExchangeSignatures.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/libtransactions/BlockReader.sol
 loopring-protocols/packages/loopring_v3/contracts/./core/impl/LoopringV3.sol
-loopring-protocols/packages/loopring_v3/contracts/./core/impl/VerificationKeys.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/AddressUtil.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/Create2.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/Drainable.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/ERC20SafeTransfer.sol
-loopring-protocols/packages/loopring_v3/contracts/./lib/FloatUtil.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/Poseidon.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/SignatureUtil.sol
 loopring-protocols/packages/loopring_v3/contracts/./lib/SimpleProxy.sol
@@ -78,8 +71,6 @@ loopring-protocols/packages/loopring_v3/contracts/./thirdparty/proxies/Upgradabi
 loopring-protocols/packages/loopring_v3/contracts/./thirdparty/verifiers/BatchVerifier.sol
 loopring-protocols/packages/loopring_v3/contracts/./thirdparty/verifiers/Verifier.sol
 makerdao-dss/src/./abaci.sol
-makerdao-dss/src/./clip.sol
-makerdao-dss/src/./spot.sol
 makerdao-dss/src/./test/dog.t.sol
 makerdao-dss/src/./vat.sol
 marketplace-contracts/contracts/./commons/ContextMixin.sol
@@ -101,7 +92,6 @@ NEST-Oracle-V3.6/contracts/./NestVote.sol
 NEST-Oracle-V3.6/contracts/./NNIncome.sol
 NEST-Oracle-V3.6/contracts/./NTokenController.sol
 NEST-Oracle-V3.6/contracts/./NToken.sol
-NEST-Oracle-V3.6/contracts/./test/IBNEST.sol
 NEST-Oracle-V3.6/contracts/./test/NNToken.sol
 NEST-Oracle-V3.6/contracts/./test/PostInOneBlock.sol
 NEST-Oracle-V3.6/contracts/./test/TestERC20.sol
@@ -112,7 +102,6 @@ safe-contracts/contracts/./base/Executor.sol
 safe-contracts/contracts/./base/FallbackManager.sol
 safe-contracts/contracts/./base/GuardManager.sol
 safe-contracts/contracts/./base/ModuleManager.sol
-safe-contracts/contracts/./base/OwnerManager.sol
 safe-contracts/contracts/./common/SecuredTokenTransfer.sol
 safe-contracts/contracts/./common/SignatureDecoder.sol
 safe-contracts/contracts/./common/StorageAccessible.sol
@@ -129,14 +118,7 @@ safe-contracts/contracts/./proxies/GnosisSafeProxy.sol
 safe-contracts/contracts/./proxies/IProxyCreationCallback.sol
 safe-contracts/contracts/./test/ERC1155Token.sol
 safe-contracts/contracts/./test/TestHandler.sol
-synthetix/contracts/./Math.sol
 synthetix/contracts/./MinimalProxyFactory.sol
-synthetix/contracts/./SafeDecimalMath.sol
-synthetix/contracts/./SynthUtil.sol
-synthetix/contracts/./test-helpers/MockEtherCollateral.sol
-synthetix/contracts/./test-helpers/MockExchanger.sol
-synthetix/contracts/./test-helpers/PublicMath.sol
-synthetix/contracts/./test-helpers/PublicSafeDecimalMath.sol
 synthetix/contracts/./test-helpers/TestableMinimalProxyFactory.sol
 uFragments/contracts/./_external/ERC20Detailed.sol
 uFragments/contracts/./_external/Initializable.sol


### PR DESCRIPTION
This PR provides a patch that updates contract files with changes needed for them to be compiled due to type mismatches (due to the types `int` and `uint` not being aliases for `int256` and `uint256` in IELE).