### PR TITLE
Minor edit in handling of FunctionCallOptions

### DIFF
--- a/libsolidity/codegen/IeleCompiler.cpp
+++ b/libsolidity/codegen/IeleCompiler.cpp
@@ -4720,7 +4720,6 @@ bool IeleCompiler::visit(const FunctionCallOptions &functionCallOptions) {
                  functionCallOptions.expression().annotation().type);
 
   int numOptions = functionCallOptions.options().size() ;
-  solAssert(numOptions <= 2, "");
 
   for (int i = 0; i < numOptions; i++) {
     if (functionCallOptions.names()[i]->compare("gas") == 0) {
@@ -4739,8 +4738,10 @@ bool IeleCompiler::visit(const FunctionCallOptions &functionCallOptions) {
                              functionCallOptions.options()[i]->annotation().type,
                              UInt);
       values.insert(values.begin() + functionType->valueIndex(), OptionValue->getValue());
+    } else if (functionCallOptions.names()[i]->compare("salt") == 0) {
+      solUnimplemented("Not yet implemented - salted create.");
     } else {
-      solAssert(false, "not implemented yet");
+      solAssert(false, "Unknown call option.");
     }
   }
 

--- a/test/failing-exec-tests
+++ b/test/failing-exec-tests
@@ -38,9 +38,7 @@
 -t !semanticTests/state/block_gaslimit
 -t !semanticTests/state/blockhash_basic
 -t !semanticTests/state/block_timestamp
--t !semanticTests/state/msg_data
 -t !semanticTests/state/msg_sender
--t !semanticTests/state/msg_sig
 -t !semanticTests/state/tx_gasprice
 -t !semanticTests/state/tx_origin
 -t !semanticTests/state/uncalled_blockhash

--- a/test/out-of-scope-exec-tests
+++ b/test/out-of-scope-exec-tests
@@ -124,6 +124,8 @@
 -t !semanticTests/smoke/fallback
 -t !semanticTests/snark
 -t !semanticTests/specialFunctions/abi_functions_member_access
+-t !semanticTests/state/msg_data
+-t !semanticTests/state/msg_sig
 -t !semanticTests/structs/recursive_struct_2
 -t !semanticTests/structs/struct_delete_storage_nested_small
 -t !semanticTests/structs/struct_delete_storage_small


### PR DESCRIPTION
This PR removes an unnecessary assertion and separates out the case of salt as an unimplemented feature.

Also, identified two out of scope tests.