### PR TITLE
Adding a new abi field, ieleName, with the name of the iele function …

### DIFF
--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -59,6 +59,7 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 		Json::Value method;
 		method["type"] = "function";
 		method["name"] = it.second->declaration().name();
+		method["ieleName"] = externalFunctionType->externalSignature();
 		method["stateMutability"] = stateMutabilityToString(externalFunctionType->stateMutability());
 		method["inputs"] = formatTypeList(
 			externalFunctionType->parameterNames(),

--- a/test/libsolidity/ABIJson/basic_test.sol
+++ b/test/libsolidity/ABIJson/basic_test.sol
@@ -5,6 +5,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/empty_name_input_parameter_with_named_one.sol
+++ b/test/libsolidity/ABIJson/empty_name_input_parameter_with_named_one.sol
@@ -9,6 +9,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(uint256,uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/empty_name_return_parameters.sol
+++ b/test/libsolidity/ABIJson/empty_name_return_parameters.sol
@@ -7,6 +7,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/events.sol
+++ b/test/libsolidity/ABIJson/events.sol
@@ -55,6 +55,7 @@ contract test {
 //     "type": "event"
 //   },
 //   {
+//     "ieleName": "f(uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/function_type.sol
+++ b/test/libsolidity/ABIJson/function_type.sol
@@ -5,6 +5,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "g(function)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/function_type_extended.sol
+++ b/test/libsolidity/ABIJson/function_type_extended.sol
@@ -5,6 +5,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "g(function)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/global_struct.sol
+++ b/test/libsolidity/ABIJson/global_struct.sol
@@ -8,6 +8,7 @@ contract C {
 //     :C
 // [
 //   {
+//     "ieleName": "f((uint256))",
 //     "inputs":
 //     [
 //       {
@@ -30,6 +31,7 @@ contract C {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "g((uint256))",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/inherited.sol
+++ b/test/libsolidity/ABIJson/inherited.sol
@@ -24,6 +24,7 @@ contract Derived is Base {
 //     "type": "event"
 //   },
 //   {
+//     "ieleName": "baseFunction(uint256)",
 //     "inputs":
 //     [
 //       {
@@ -78,6 +79,7 @@ contract Derived is Base {
 //     "type": "event"
 //   },
 //   {
+//     "ieleName": "baseFunction(uint256)",
 //     "inputs":
 //     [
 //       {
@@ -99,6 +101,7 @@ contract Derived is Base {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "derivedFunction(bytes32)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/library_function.sol
+++ b/test/libsolidity/ABIJson/library_function.sol
@@ -12,6 +12,7 @@ library test {
 //     :test
 // [
 //   {
+//     "ieleName": "f1(uint256[],X)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/multiple_methods.sol
+++ b/test/libsolidity/ABIJson/multiple_methods.sol
@@ -6,6 +6,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(uint256)",
 //     "inputs":
 //     [
 //       {
@@ -27,6 +28,7 @@ contract test {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "g(uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/multiple_methods_order.sol
+++ b/test/libsolidity/ABIJson/multiple_methods_order.sol
@@ -7,6 +7,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "c(uint256)",
 //     "inputs":
 //     [
 //       {
@@ -28,6 +29,7 @@ contract test {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "f(uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/multiple_params.sol
+++ b/test/libsolidity/ABIJson/multiple_params.sol
@@ -5,6 +5,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(uint256,uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/payable_function.sol
+++ b/test/libsolidity/ABIJson/payable_function.sol
@@ -6,6 +6,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f()",
 //     "inputs": [],
 //     "name": "f",
 //     "outputs": [],
@@ -13,6 +14,7 @@ contract test {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "g()",
 //     "inputs": [],
 //     "name": "g",
 //     "outputs": [],

--- a/test/libsolidity/ABIJson/pure_function.sol
+++ b/test/libsolidity/ABIJson/pure_function.sol
@@ -6,6 +6,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "boo(uint32)",
 //     "inputs":
 //     [
 //       {
@@ -27,6 +28,7 @@ contract test {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "foo(uint256,uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/return_param_in_abi.sol
+++ b/test/libsolidity/ABIJson/return_param_in_abi.sol
@@ -23,6 +23,7 @@ contract test {
 //     "type": "constructor"
 //   },
 //   {
+//     "ieleName": "ret()",
 //     "inputs": [],
 //     "name": "ret",
 //     "outputs":

--- a/test/libsolidity/ABIJson/return_structs.sol
+++ b/test/libsolidity/ABIJson/return_structs.sol
@@ -9,6 +9,7 @@ contract C {
 //     :C
 // [
 //   {
+//     "ieleName": "f()",
 //     "inputs": [],
 //     "name": "f",
 //     "outputs":

--- a/test/libsolidity/ABIJson/return_structs_with_contracts.sol
+++ b/test/libsolidity/ABIJson/return_structs_with_contracts.sol
@@ -8,6 +8,7 @@ contract C {
 //     :C
 // [
 //   {
+//     "ieleName": "f()",
 //     "inputs": [],
 //     "name": "f",
 //     "outputs":

--- a/test/libsolidity/ABIJson/structs_and_arrays.sol
+++ b/test/libsolidity/ABIJson/structs_and_arrays.sol
@@ -6,6 +6,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "f(string,bytes,uint256[])",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/structs_in_libraries.sol
+++ b/test/libsolidity/ABIJson/structs_in_libraries.sol
@@ -9,6 +9,7 @@ library L {
 //     :L
 // [
 //   {
+//     "ieleName": "g(L.S)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/ABIJson/view_function.sol
+++ b/test/libsolidity/ABIJson/view_function.sol
@@ -6,6 +6,7 @@ contract test {
 //     :test
 // [
 //   {
+//     "ieleName": "boo(uint32)",
 //     "inputs":
 //     [
 //       {
@@ -27,6 +28,7 @@ contract test {
 //     "type": "function"
 //   },
 //   {
+//     "ieleName": "foo(uint256,uint256)",
 //     "inputs":
 //     [
 //       {

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -618,7 +618,7 @@ BOOST_AUTO_TEST_CASE(output_selection_dependent_contract)
 	Json::Value contract = getContractResult(result, "fileA", "A");
 	BOOST_CHECK(contract.isObject());
 	BOOST_CHECK(contract["abi"].isArray());
-	BOOST_CHECK_EQUAL(util::jsonCompactPrint(contract["abi"]), "[{\"inputs\":[],\"name\":\"f\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]");
+	BOOST_CHECK_EQUAL(util::jsonCompactPrint(contract["abi"]), "[{\"ieleName\":\"f()\",\"inputs\":[],\"name\":\"f\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]");
 }
 
 BOOST_AUTO_TEST_CASE(output_selection_dependent_contract_with_import)
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE(output_selection_dependent_contract_with_import)
 	Json::Value contract = getContractResult(result, "fileA", "A");
 	BOOST_CHECK(contract.isObject());
 	BOOST_CHECK(contract["abi"].isArray());
-	BOOST_CHECK_EQUAL(util::jsonCompactPrint(contract["abi"]), "[{\"inputs\":[],\"name\":\"f\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]");
+	BOOST_CHECK_EQUAL(util::jsonCompactPrint(contract["abi"]), "[{\"ieleName\":\"f()\",\"inputs\":[],\"name\":\"f\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]");
 }
 
 BOOST_AUTO_TEST_CASE(filename_with_colon)


### PR DESCRIPTION
This PR adds a new ABI field named `ieleName` that contains the IELE generated name that corresponds to each Solidity function.