### PR TITLE
pin nix version to 2.3.16 and bump action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,12 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: Install Cachix
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
This PR is a fix for CI failures related to a new Nix release. It is based on a PR that fixed a similar issue for the `iele-semantics` repo (https://github.com/runtimeverification/iele-semantics/pull/326). Like that PR, it does two things:
 - Bumps the github actions we use for nix (install-nix, install-cachix) to their newest versions.
 - Pins Nix to 2.3.16 as a temporary fix, as 2.4 breaks on macos at the moment.
